### PR TITLE
Extra Wrappers

### DIFF
--- a/src/SoapySDR.jl
+++ b/src/SoapySDR.jl
@@ -16,6 +16,7 @@ include("lowlevel/Errors.jl")    # Done
 include("lowlevel/Formats.jl")   # Done
 include("lowlevel/Types.jl")     # Done
 include("lowlevel/Device.jl")
+include("lowlevel/Modules.jl")
 include("typemap.jl")
 include("highlevel.jl")
 

--- a/src/highlevel.jl
+++ b/src/highlevel.jl
@@ -242,6 +242,16 @@ function Base.show(io::IO, ::MIME"text/plain", c::Channel)
     end
 end
 
+"""
+    native_stream_format(c::Channel)
+
+Returns the format type and fullscale resolution of the native stream.
+"""
+function native_stream_format(c::Channel)
+    fmt, fullscale = SoapySDRDevice_getNativeStreamFormat(c.device.ptr, c.direction, c.idx)
+    _stream_type_soapy2jl[unsafe_string(fmt)], fullscale
+end
+
 struct ChannelList <: AbstractVector{Channel}
     device::Device
     direction::Direction
@@ -456,8 +466,8 @@ function Base.print(io::IO, sf::StreamFormat)
 end
 
 function StreamFormat(s::String)
-    if haskey(_stream_type_map, s)
-        T = _stream_type_map[s]
+    if haskey(_stream_type_soapy2jl, s)
+        T = _stream_type_soapy2jl[s]
         return StreamFormat(T)
     else
         error("Unknown format")

--- a/src/lowlevel/Device.jl
+++ b/src/lowlevel/Device.jl
@@ -370,6 +370,24 @@ function SoapySDRDevice_getStreamFormats(device, direction, channel)
 end
 
 """
+Get the hardware's native stream format for this channel.
+This is the format used by the underlying transport layer,
+and the direct buffer access API calls (when available).
+
+param device a pointer to a device instance
+param direction the channel direction RX or TX
+param channel an available channel on the device
+param [out] fullScale the maximum possible value
+return the native stream buffer format string
+"""
+function SoapySDRDevice_getNativeStreamFormat(device, direction, channel)
+    #SOAPY_SDR_API char *SoapySDRDevice_getNativeStreamFormat(const SoapySDRDevice *device, const int direction, const size_t channel, double *fullScale);
+    fullscale = Ref{Cdouble}()
+    fmt = @check_error ccall((:SoapySDRDevice_getNativeStreamFormat, lib), Cstring, (Ptr{SoapySDRDevice}, Cint, Csize_t, Ref{Cdouble}), device, direction, channel, fullscale)
+    return fmt, fullscale[]
+end
+
+"""
 Initialize a stream given a list of channels and stream arguments.
 The implementation may change switches or power-up components.
 All stream API calls should be usable with the new stream object

--- a/src/lowlevel/Modules.jl
+++ b/src/lowlevel/Modules.jl
@@ -1,0 +1,124 @@
+# 
+# SoapySDR Modules API
+#
+# https://github.com/pothosware/SoapySDR/blob/1cf5a539a21414ff509ff7d0eedfc5fa8edb90c6/include/SoapySDR/Modules.h
+
+""" Query the root installation path"""
+function SoapySDR_getRootPath()
+    #SOAPY_SDR_API const char *SoapySDR_getRootPath(void);
+    @check_error ccall((:SoapySDR_getRootPath, lib), Cstring, ())
+end
+
+"""
+The list of paths automatically searched by loadModules().
+
+param [out] length the number of elements in the result.
+return a list of automatically searched file paths
+"""
+function SoapySDR_listSearchPaths()
+    #SOAPY_SDR_API char **SoapySDR_listSearchPaths(size_t *length);
+    len = Ref{Csize_t}()
+    ptr = @check_error ccall((:SoapySDR_listSearchPaths, lib), Ptr{Cstring}, (Ref{Csize_t},), len)
+    (ptr, len[])
+end
+
+"""
+List all modules found in default path.
+The result is an array of strings owned by the caller.
+
+param [out] length the number of elements in the result.
+return a list of file paths to loadable modules
+"""
+function SoapySDR_listModules()
+    #SOAPY_SDR_API char **SoapySDR_listModules(size_t *length);
+    len = Ref{Csize_t}()
+    ptr = @check_error ccall((:SoapySDR_listModules, lib), Ptr{Cstring}, (Ref{Csize_t},), len)
+    (ptr, len[])
+end
+
+"""
+List all modules found in the given path.
+The result is an array of strings owned by the caller.
+
+param path a directory on the system
+param [out] length the number of elements in the result.
+return a list of file paths to loadable modules
+"""
+function SoapySDR_listModulesPath(path)
+    #SOAPY_SDR_API char **SoapySDR_listModulesPath(const char *path, size_t *length);
+    len = Ref{Csize_t}()
+    ptr = @check_error ccall((:SoapySDR_listModulesPath, lib), Ptr{Cstring}, (Cstring, Ref{Csize_t}), path, len)
+    (ptr, len[])
+end
+
+"""
+Load a single module given its file system path.
+The caller must free the result error string.
+
+param path the path to a specific module file]
+return an error message, empty on success
+"""
+function SoapySDR_loadModule(path)
+    #SOAPY_SDR_API char *SoapySDR_loadModule(const char *path);
+    err = @check_error ccall((:SoapySDR_loadModule, lib), SoapySDRKwargs, (Cstring,), path)
+    err
+end
+
+"""
+List all registration loader errors for a given module path.
+The resulting dictionary contains all registry entry names
+provided by the specified module. The value of each entry
+is an error message string or empty on successful load.
+
+param path the path to a specific module file
+return a dictionary of registry names to error messages
+"""
+function SoapySDR_listLoaderResult(path)
+    #SOAPY_SDR_API SoapySDRKwargs SoapySDR_getLoaderResult(const char *path);
+    kwargs = @check_error ccall((:SoapySDR_listLoaderResult, lib), SoapySDRKwargs, (Cstring,), path)
+    kwargs
+end
+
+"""
+Get a version string for the specified module.
+Modules may optionally provide version strings.
+
+param path the path to a specific module file
+return a version string or empty if no version provided
+"""
+function SoapySDR_getModuleVersion(path)
+    #SOAPY_SDR_API char *SoapySDR_getModuleVersion(const char *path);
+    ver = @check_error ccall((:SoapySDR_getModuleVersion, lib), Cstring, (Cstring,), path)
+    ver
+end
+
+"""
+Unload a module that was loaded with loadModule().
+The caller must free the result error string.
+
+param path the path to a specific module file
+return an error message, empty on success
+"""
+function SoapySDR_unloadModule(path)
+    #SOAPY_SDR_API char *SoapySDR_unloadModule(const char *path);
+    err = @check_error ccall((:SoapySDR_loadModules, lib), Cstring, (Cstring,), path)
+    err
+end
+
+"""
+Load the support modules installed on this system.
+This call will only actually perform the load once.
+Subsequent calls are a NOP.
+"""
+function SoapySDR_loadModules()
+    #SOAPY_SDR_API void SoapySDR_loadModules(void);
+    @check_error ccall((:SoapySDR_loadModules, lib), Cvoid, ())
+end
+
+"""
+Unload all currently loaded support modules.
+"""
+function SoapySDR_unloadModules()
+    #SOAPY_SDR_API void SoapySDR_unloadModules(void);
+    @check_error ccall((:SoapySDR_unloadModule, lib), Cvoid, ())
+end

--- a/src/lowlevel/Modules.jl
+++ b/src/lowlevel/Modules.jl
@@ -2,6 +2,9 @@
 # SoapySDR Modules API
 #
 # https://github.com/pothosware/SoapySDR/blob/1cf5a539a21414ff509ff7d0eedfc5fa8edb90c6/include/SoapySDR/Modules.h
+#
+# NOTE: This is an API for manually loading Soapy Modules. It is recommended that developers
+# package via BinaryBuilder+Yggdrasil for Julia.
 
 """ Query the root installation path"""
 function SoapySDR_getRootPath()

--- a/src/typemap.jl
+++ b/src/typemap.jl
@@ -26,30 +26,38 @@ Parameter `T` indicates the number of bits.
 """
 struct ComplexUInt{T} <: AbstractComplexInteger; end
 
+const _stream_type_pairs = [
+    (SOAPY_SDR_CF64, Complex{Float64}),
+    (SOAPY_SDR_CF32, Complex{Float32}),
+    (SOAPY_SDR_CS32, Complex{Int32}),
+    (SOAPY_SDR_CU32, Complex{UInt32}),
+    (SOAPY_SDR_CS16, Complex{Int16}),
+    (SOAPY_SDR_CU16, Complex{UInt16}),
+    (SOAPY_SDR_CS12, ComplexInt{12}),
+    (SOAPY_SDR_CU12, ComplexUInt{12}),
+    (SOAPY_SDR_CS8, Complex{Int8}),
+    (SOAPY_SDR_CU8, Complex{UInt8}),
+    (SOAPY_SDR_CS4, ComplexInt{4}),
+    (SOAPY_SDR_CU4, ComplexUInt{4}),
+    (SOAPY_SDR_F64, Float64),
+    (SOAPY_SDR_F32, Float32),
+    (SOAPY_SDR_S32, Int32),
+    (SOAPY_SDR_U32, UInt32),
+    (SOAPY_SDR_S16, Int16),
+    (SOAPY_SDR_U16, UInt16),
+    (SOAPY_SDR_S8, Int8),
+    (SOAPY_SDR_U8, UInt8) ]
+
 """
 Type map from SoapySDR Stream formats to Julia types.
 
 Note: Please see ComplexUInt and ComplexUInt if using 12 or 4 bit complex types.
 """
-const _stream_type_map = Dict{String, Type}(
-    SOAPY_SDR_CF64 => Complex{Float64},
-    SOAPY_SDR_CF32 => Complex{Float32},
-    SOAPY_SDR_CS32 => Complex{Int32},
-    SOAPY_SDR_CU32 => Complex{UInt32},
-    SOAPY_SDR_CS16 => Complex{Int16},
-    SOAPY_SDR_CU16 => Complex{UInt16},
-    SOAPY_SDR_CS12 => ComplexInt{12},
-    SOAPY_SDR_CU12 => ComplexUInt{12},
-    SOAPY_SDR_CS8  => Complex{Int8},
-    SOAPY_SDR_CU8  => Complex{UInt8},
-    SOAPY_SDR_CS4  => ComplexInt{4},
-    SOAPY_SDR_CU4  => ComplexUInt{4},
-    SOAPY_SDR_F64  => Float64,
-    SOAPY_SDR_F32  => Float32,
-    SOAPY_SDR_S32  => Int32,
-    SOAPY_SDR_U32  => UInt32,
-    SOAPY_SDR_S16  => Int16,
-    SOAPY_SDR_U16  => UInt16,
-    SOAPY_SDR_S8   => Int8,
-    SOAPY_SDR_U8   => UInt8
-)
+const _stream_type_soapy2jl = Dict{String, Type}(_stream_type_pairs)
+
+"""
+Type map from SoapySDR Stream formats to Julia types.
+
+Note: Please see ComplexUInt and ComplexUInt if using 12 or 4 bit complex types.
+"""
+const _stream_type_jl2soapy = Dict{Type, String}(reverse.(_stream_type_pairs))


### PR DESCRIPTION
re #8 #14 . Adds native stream API call and wraps the Module API. After wrapping the Module API and doing some experimentation, I don't think it is really of any benefit to us. BinaryBuilder and Yggdrasil are the best solution. Though the work is done wrapping it, so it seems good to have it in the tree if someone comes along with a use case and needs a decent starting point. 