### PR TITLE
WIP/RFC: include modules available from Julia Pkg by default

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,20 +7,28 @@ version = "0.1.0"
 
 [deps]
 Intervals = "d8418881-c3e1-53bb-8760-2df7ec849ed5"
+SoapyLMS7_jll = "e7ed14a0-13eb-5dc7-93e2-6133b2eb8bed"
+SoapyRTLSDR_jll = "7bed6c1d-f2db-586c-9908-488058499e34"
+SoapyUHD_jll = "5710b6fb-c5a3-5f8f-93a5-d73c28ee0e84"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 soapysdr_jll = "343a40d9-ed99-5d34-8b56-649aaa4ecee6"
+xtrx_jll = "f7ce82bc-bc1e-5125-bd1d-6a84dd39bfb4"
 
 [compat]
-soapysdr_jll  = "0.8"
-Unitful = "1"
 Intervals = "1"
+Unitful = "1"
 julia = "1.6"
+soapysdr_jll = "0.8"
+SoapyLMS7_jll = "20.10.0"
+SoapyRTLSDR_jll = "0.3"
+SoapyUHD_jll = "0.4"
+xtrx_jll = "0.1"
 
 [extras]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 BinaryBuilder = "12aac903-9f7c-5d81-afc2-d9565ea332ae"
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test", "Pkg", "BinaryBuilder", "Libdl"]

--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ version = "0.1.0"
 
 [deps]
 Intervals = "d8418881-c3e1-53bb-8760-2df7ec849ed5"
+Preferences = "21216c6a-2e73-6563-6e65-726566657250"
 SoapyLMS7_jll = "e7ed14a0-13eb-5dc7-93e2-6133b2eb8bed"
 SoapyRTLSDR_jll = "7bed6c1d-f2db-586c-9908-488058499e34"
 SoapyUHD_jll = "5710b6fb-c5a3-5f8f-93a5-d73c28ee0e84"
@@ -16,13 +17,14 @@ xtrx_jll = "f7ce82bc-bc1e-5125-bd1d-6a84dd39bfb4"
 
 [compat]
 Intervals = "1"
-Unitful = "1"
-julia = "1.6"
-soapysdr_jll = "0.8"
 SoapyLMS7_jll = "20.10.0"
 SoapyRTLSDR_jll = "0.3"
 SoapyUHD_jll = "0.4"
+Unitful = "1"
+julia = "1.6"
+soapysdr_jll = "0.8"
 xtrx_jll = "0.1"
+Preferences = "1"
 
 [extras]
 BinaryBuilder = "12aac903-9f7c-5d81-afc2-d9565ea332ae"

--- a/src/SoapySDR.jl
+++ b/src/SoapySDR.jl
@@ -9,7 +9,7 @@ using Unitful
 using Unitful.DefaultSymbols
 
 # SoapySDR modules in Yggdrasil
-#using SoapyLMS7_jll
+using SoapyLMS7_jll
 using SoapyRTLSDR_jll
 using SoapyUHD_jll
 using xtrx_jll

--- a/src/SoapySDR.jl
+++ b/src/SoapySDR.jl
@@ -3,9 +3,17 @@ module SoapySDR
 using soapysdr_jll
 const lib = soapysdr_jll.libsoapysdr
 
+# Julia support for Units and Interval for Highlevel API
 using Intervals
 using Unitful
 using Unitful.DefaultSymbols
+
+# SoapySDR modules in Yggdrasil
+#using SoapyLMS7_jll
+using SoapyRTLSDR_jll
+using SoapyUHD_jll
+using xtrx_jll
+
 const dB = u"dB"
 const GC = Base.GC
 


### PR DESCRIPTION
This makes known SoapySDR modules a dependency and a default include. Some modules throw warnings (xtrx) and others don't seem to like the GHA CI environment (LMS7). 

I'm not sure if this is a good idea, though I discussed some merits in #14.