### PR TITLE
Address several issues discovered in testing

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -51,7 +51,7 @@ channel.gain = 42u"dB"
 channel.sample_rate = 2.1u"MHz"
 
 # Open a (potentially multichannel) stream on this channel
-stream = SoapySDR.Stream(ComplexF32, [channel])
+stream = SoapySDR.Stream([channel])
 SoapySDR.activate!(stream)
 
 # Write out random noise
@@ -70,9 +70,9 @@ channel.gain = 42u"dB"
 channel.sample_rate = 2.1u"MHz"
 
 # Open a (potentially multichannel) stream on this channel
-stream = SoapySDR.Stream(ComplexF32, [channel])
+stream = SoapySDR.Stream([channel])
 SoapySDR.activate!(stream)
 
-# Collect data
-Base.read(stream, 10000)
+# Collect all available samples in the buffer
+Base.read(stream)
 ```

--- a/src/highlevel.jl
+++ b/src/highlevel.jl
@@ -536,10 +536,11 @@ Base.length(sb::SampleBuffer) = length(sb.bufs[1])
 function Base.read(s::Stream{T}, n::Int; kwargs...) where {T}
     bufs = ntuple(_->Vector{T}(undef, n), s.nchannels)
     nread, flags, timens = _read!(s, bufs; kwargs...)
-    if nread != n
-        @info("assertion debugging", nread, n)
-        @assert nread == n
-    end
+    # By definition of read, we can allow fewer samples than requested
+    #if nread != n
+    #    @info("assertion debugging", nread, n)
+    #    @assert nread == n
+    #end
     SampleBuffer(bufs, flags, timens)
 end
 

--- a/src/typemap.jl
+++ b/src/typemap.jl
@@ -61,3 +61,17 @@ Type map from SoapySDR Stream formats to Julia types.
 Note: Please see ComplexUInt and ComplexUInt if using 12 or 4 bit complex types.
 """
 const _stream_type_jl2soapy = Dict{Type, String}(reverse.(_stream_type_pairs))
+
+function _stream_map_jl2soapy(stream_type)
+    if !haskey(_stream_type_jl2soapy, stream_type)
+        error("Unsupported stream type: " + stream_type)
+    end
+    return _stream_type_jl2soapy[stream_type]
+end
+
+function _stream_map_soapy2jl(stream_type)
+    if !haskey(_stream_type_soapy2jl, stream_type)
+        error("Unsupported stream type: " + stream_type)
+    end
+    return _stream_type_soapy2jl[stream_type]
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -61,6 +61,8 @@ end
     @test typeof(rx_chan) == sd.Channel
     @test typeof(tx_chan) == sd.Channel
 
+    @test sd.native_stream_format(rx_chan)[1] == SoapySDR.ComplexInt{12} #, fullscale
+    @test sd.stream_formats(rx_chan) == [Complex{Int8}, SoapySDR.ComplexInt{12}, Complex{Int16}, ComplexF32]
 
     # Test sensor API
     sensor_list = sd.list_sensors(dev)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,33 +21,6 @@ end
 
 
 @testset "SoapySDR.jl" begin
-@testset "StreamFormat" begin
-
-    # Should not throw
-    sd.StreamFormat(sd.SOAPY_SDR_CF64)
-    sd.StreamFormat(sd.SOAPY_SDR_CF32)
-    sd.StreamFormat(sd.SOAPY_SDR_CS32)
-    sd.StreamFormat(sd.SOAPY_SDR_CU32)
-    sd.StreamFormat(sd.SOAPY_SDR_CS16)
-    sd.StreamFormat(sd.SOAPY_SDR_CU16)
-    sd.StreamFormat(sd.SOAPY_SDR_F64)
-    sd.StreamFormat(sd.SOAPY_SDR_F32)
-    sd.StreamFormat(sd.SOAPY_SDR_S32)
-    sd.StreamFormat(sd.SOAPY_SDR_U32)
-    sd.StreamFormat(sd.SOAPY_SDR_S16)
-    sd.StreamFormat(sd.SOAPY_SDR_U16)
-    sd.StreamFormat(sd.SOAPY_SDR_S8)
-    sd.StreamFormat(sd.SOAPY_SDR_U8)
-    sd.StreamFormat(sd.SOAPY_SDR_CS8)
-    sd.StreamFormat(sd.SOAPY_SDR_CU8)
-    sd.StreamFormat(sd.SOAPY_SDR_CS12)
-    sd.StreamFormat(sd.SOAPY_SDR_CU12)
-    sd.StreamFormat(sd.SOAPY_SDR_CS4)
-    sd.StreamFormat(sd.SOAPY_SDR_CU4)
-
-    # Should throw
-    @test_throws ErrorException sd.StreamFormat("nonsense")
-end
 @testset "Ranges/Display" begin
     intervalrange = sd.SoapySDRRange(0, 1, 0)
     steprange = sd.SoapySDRRange(0, 1, 0.1)
@@ -145,8 +118,13 @@ end
 
 
     rx_stream = sd.Stream(ComplexF32, [rx_chan])
-
+    @test typeof(rx_stream) == sd.Stream{ComplexF32}
     tx_stream = sd.Stream(ComplexF32, [tx_chan])
+    @test typeof(tx_stream) == sd.Stream{ComplexF32}
 
+    rx_stream = sd.Stream([rx_chan])
+    @test typeof(rx_stream) == sd.Stream{sd.ComplexInt{12}}
+    tx_stream = sd.Stream([tx_chan])
+    @test typeof(tx_stream) == sd.Stream{sd.ComplexInt{12}}
 end
 end


### PR DESCRIPTION
- Partially addresses #17 by removing the assert in `read`, and allowing fewer samples as allowed by the semantics of Julia's `read`

- Simplifies the SoapySDR <-> Julia Type pathway. We eliminate the `StreamFormat` container, and just use a few helper functions to keep this abstraction from leaking through the high level API. 

- Constructing a new `Stream` will use the native device format by default (we have multiple dispatch, so we should use it.). It is also now aware of the MTU, thus giving a simplified `read` function without a specified length.

I think this should encapsulate the API changes to address the issues discovered in testing (thanks @mbaz !) I'll need to add some more docs here to full clarify how the `Stream` interface works, mainly regarding `activate!/deactivate!` functions if not using continuous processing. (I'm investigating if we have IO interface semantics in Base for this already)  

re: #17 #13 #12 #8
