### PR TITLE
WIP: Initial API (re)integration

### DIFF
--- a/src/SoapySDR.jl
+++ b/src/SoapySDR.jl
@@ -17,11 +17,18 @@ include("lowlevel/Formats.jl")   # Done
 include("lowlevel/Types.jl")     # Done
 include("lowlevel/Device.jl")
 include("lowlevel/Modules.jl")
+include("lowlevel/Logger.jl")
 include("typemap.jl")
 include("typewrappers.jl")
 include("highlevel.jl")
+include("loghandler.jl")
 
 const SDRStream = Stream
 export SDRStream
+
+function __init__()
+    julia_log_handler = @cfunction(logger_soapy2jl, Cvoid, (Cint, Cstring))
+    SoapySDR_registerLogHandler(julia_log_handler)
+end
 
 end

--- a/src/highlevel.jl
+++ b/src/highlevel.jl
@@ -565,18 +565,14 @@ SoapySDRDevice_closeStream(s::Stream) = SoapySDRDevice_closeStream(s.d, s)
 streamtype(::Stream{T}) where T = T
 
 function Base.setproperty!(c::Stream, s::Symbol, v)
-    if s === :mtu
-        c.mtu
-    else
-        return setfield!(c, s, v)
-    end
+    return setfield!(c, s, v)
 end
 
-function Base.getproperty(c::Stream, s::Symbol)
+function Base.getproperty(stream::Stream, s::Symbol)
     if s === :mtu
-        SoapySDRDevice_getStreamMTU(c.device.ptr, c.ptr)
+        SoapySDRDevice_getStreamMTU(stream.d.ptr, stream.ptr)
     else
-        return getfield(c, s)
+        return getfield(stream, s)
     end
 end
 

--- a/src/highlevel.jl
+++ b/src/highlevel.jl
@@ -459,6 +459,11 @@ function Base.getindex(d::Device, se::SensorComponent)
     unsafe_string(SoapySDRDevice_readSensor(d.ptr, Cstring(unsafe_convert(Ptr{UInt8}, se.name))))
 end
 
+function Base.setindex!(c::Channel, gain::typeof(1.0dB), ge::GainElement)
+    SoapySDRDevice_setGainElement(c.device, c.direction, c.idx, Cstring(unsafe_convert(Ptr{UInt8}, ge.name)), gain.val)
+    return gain
+end
+
 
 ## GainElement
 
@@ -480,10 +485,6 @@ end
 gainrange(c::Channel, ge::GainElement) =
     return _gainrange(SoapySDRDevice_getGainElementRange(c.device, c.direction, c.idx, Cstring(unsafe_convert(Ptr{UInt8}, ge.name))))
 
-function Base.setindex!(c::Channel, gain::typeof(1.0dB), ge::GainElement)
-    SoapySDRDevice_setGainElement(c.device, c.direction, c.idx, Cstring(unsafe_convert(Ptr{UInt8}, ge.name, gain.val)))
-    return gain
-end
 
 function _hzrange(soapyr::SoapySDRRange)
     if soapyr.step == 0.0

--- a/src/loghandler.jl
+++ b/src/loghandler.jl
@@ -1,0 +1,29 @@
+#
+# Setup the a handler from SoapySDR log messages into Julia
+#
+
+function logger_soapy2jl(level, cmessage)
+    #SOAPY_SDR_FATAL    = 1 #!< A fatal error. The application will most likely terminate. This is the highest priority.
+    #SOAPY_SDR_CRITICAL = 2 #!< A critical error. The application might not be able to continue running successfully.
+    #SOAPY_SDR_ERROR    = 3 #!< An error. An operation did not complete successfully, but the application as a whole is not affected.
+    #SOAPY_SDR_WARNING  = 4 #!< A warning. An operation completed with an unexpected result.
+    #SOAPY_SDR_NOTICE   = 5 #!< A notice, which is an information with just a higher priority.
+    #SOAPY_SDR_INFO     = 6 #!< An informational message, usually denoting the successful completion of an operation.
+    #SOAPY_SDR_DEBUG    = 7 #!< A debugging message.
+    #SOAPY_SDR_TRACE    = 8 #!< A tracing message. This is the lowest priority.
+    #SOAPY_SDR_SSI      = 9 #!< Streaming status indicators such as "U" (underflow) and "O" (overflow).
+
+    message = unsafe_string(cmessage)
+    level = SoapySDRLogLevel(level)
+    if level in (SOAPY_SDR_FATAL, SOAPY_SDR_CRITICAL, SOAPY_SDR_ERROR)
+        @error message
+    elseif level == SOAPY_SDR_WARNING
+        @warn message
+    elseif level in (SOAPY_SDR_NOTICE, SOAPY_SDR_INFO)
+        @info message
+    elseif level in (SOAPY_SDR_DEBUG, SOAPY_SDR_TRACE, SOAPY_SDR_SSI)
+        @debug message
+    else
+        println("SoapySDR_jll: ", message)
+    end
+end

--- a/src/lowlevel/Device.jl
+++ b/src/lowlevel/Device.jl
@@ -307,10 +307,21 @@ function SoapySDRDevice_getGainElement(device, direction, channel, name)
         device, direction, channel, name)
 end
 
+
+"""
+Set the value of a amplification element in a chain.
+
+param device a pointer to a device instance
+param direction the channel direction RX or TX
+param channel an available channel on the device
+param name the name of an amplification element
+param value the new amplification value in dB
+return an error code or 0 for success
+"""
 function SoapySDRDevice_setGainElement(device, direction, channel, name, val)
-    err = @check_error ccall((:SoapySDRDevice_getGainElement, lib), Cint, (Ptr{SoapySDRDevice}, Cint, Csize_t, Cstring, Cdouble),
+    # note: the C API does not match the C++ API. c++ returns void here w/o error code
+    @check_error ccall((:SoapySDRDevice_getGainElement, lib), Cvoid, (Ptr{SoapySDRDevice}, Cint, Csize_t, Cstring, Cdouble),
         device, direction, channel, name, val)
-    @assert err == 0
     return nothing
 end
 

--- a/src/lowlevel/Logger.jl
+++ b/src/lowlevel/Logger.jl
@@ -1,0 +1,72 @@
+#
+# SoapySDR logger
+# https://github.com/pothosware/SoapySDR/blob/1cf5a539a21414ff509ff7d0eedfc5fa8edb90c6/include/SoapySDR/Logger.h
+#
+
+
+@enum SoapySDRLogLevel begin
+    SOAPY_SDR_FATAL    = 1 #!< A fatal error. The application will most likely terminate. This is the highest priority.
+    SOAPY_SDR_CRITICAL = 2 #!< A critical error. The application might not be able to continue running successfully.
+    SOAPY_SDR_ERROR    = 3 #!< An error. An operation did not complete successfully, but the application as a whole is not affected.
+    SOAPY_SDR_WARNING  = 4 #!< A warning. An operation completed with an unexpected result.
+    SOAPY_SDR_NOTICE   = 5 #!< A notice, which is an information with just a higher priority.
+    SOAPY_SDR_INFO     = 6 #!< An informational message, usually denoting the successful completion of an operation.
+    SOAPY_SDR_DEBUG    = 7 #!< A debugging message.
+    SOAPY_SDR_TRACE    = 8 #!< A tracing message. This is the lowest priority.
+    SOAPY_SDR_SSI      = 9 #!< Streaming status indicators such as "U" (underflow) and "O" (overflow).
+end
+
+
+
+#"""
+#Send a message to the registered logger.
+#\param logLevel a possible logging level
+#\param message a logger message string
+#"""
+#SOAPY_SDR_API void SoapySDR_log(const SoapySDRLogLevel logLevel, const char *message);
+
+#"""
+#Send a message to the registered logger.
+#\param logLevel a possible logging level
+#\param format a printf style format string
+#\param argList an argument list for the formatter
+#"""
+#SOAPY_SDR_API void SoapySDR_vlogf(const SoapySDRLogLevel logLevel, const char *format, va_list argList);
+
+#"""
+#Send a message to the registered logger.
+#\param logLevel a possible logging level
+#\param format a printf style format string
+#"""
+#static inline void SoapySDR_logf(const SoapySDRLogLevel logLevel, const char *format, ...)
+#{
+#    va_list argList;
+#    va_start(argList, format);
+#    SoapySDR_vlogf(logLevel, format, argList);
+#    va_end(argList);
+#}
+
+#"""
+#Typedef for the registered log handler function.
+#"""
+#typedef void (*SoapySDRLogHandler)(const SoapySDRLogLevel logLevel, const char *message);
+
+
+
+"""
+Register a new system log handler.
+Platforms should call this to replace the default stdio handler.
+Passing `NULL` restores the default.
+"""
+function SoapySDR_registerLogHandler(func)
+    #SOAPY_SDR_API void SoapySDR_registerLogHandler(const SoapySDRLogHandler handler);
+    ccall((:SoapySDR_registerLogHandler, lib), Cvoid, (Ptr{Cvoid},), func)
+end
+
+"""
+Set the log level threshold.
+Log messages with lower priority are dropped.
+"""
+function SoapySDR_setLogLevel(level::Cint)
+    #SOAPY_SDR_API void SoapySDR_setLogLevel(const SoapySDRLogLevel logLevel);
+end

--- a/src/typewrappers.jl
+++ b/src/typewrappers.jl
@@ -82,3 +82,16 @@ function Base.getindex(s::StringList, i::Integer)
 end
 
 SoapySDRStrings_clear(s::StringList) = @GC.preserve s SoapySDRStrings_clear(pointer_from_objref(s), s.length)
+
+
+function Base.show(io::IO, s::SoapySDRArgInfo)
+    println(io, "name: ", unsafe_string(s.units))
+    println(io, "key: ", unsafe_string(s.key))
+    println(io, "value: ", unsafe_string(s.name))
+    println(io, "description: ", unsafe_string(s.description))
+    println(io, "units: ", unsafe_string(s.units))
+    #type
+    #range
+    println(io, "options: ", StringList(s.options, s.numOptions))
+    println(io, "optionNames: ", StringList(s.optionNames, s.numOptions))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -61,7 +61,10 @@ end
     @test typeof(dev.info) == sd.OwnedKWArgs
     @test dev.driver == :LoopbackDriver
     @test dev.hardware == :LoopbackHardware
-    dev.hardwareinfo #TODO
+    @test dev.timesources == SoapySDR.TimeSource[:sw_ticks,:hw_ticks] 
+    @test dev.timesource == SoapySDR.TimeSource(:sw_ticks)
+    dev.timesource = "hw_ticks"
+    @test dev.timesource == SoapySDR.TimeSource(:hw_ticks)
 
     # Channels
     rx_chan_list = dev.rx
@@ -78,6 +81,11 @@ end
     show(io, tx_chan)
 
     #channel set/get properties
+    @test rx_chan.native_stream_format == SoapySDR.ComplexInt{12} #, fullscale
+    @test rx_chan.stream_formats == [Complex{Int8}, SoapySDR.ComplexInt{12}, Complex{Int16}, ComplexF32]
+    @test tx_chan.native_stream_format == SoapySDR.ComplexInt{12} #, fullscale
+    @test tx_chan.stream_formats == [Complex{Int8}, SoapySDR.ComplexInt{12}, Complex{Int16}, ComplexF32]
+
     rx_chan.info
     rx_chan.antenna
     rx_chan.gain
@@ -104,27 +112,6 @@ end
     tx_chan.bandwidth
     tx_chan.frequency
 
-    # Stream Formats
-    @test sd.native_stream_format(rx_chan)[1] == SoapySDR.ComplexInt{12} #, fullscale
-    @test sd.stream_formats(rx_chan) == [Complex{Int8}, SoapySDR.ComplexInt{12}, Complex{Int16}, ComplexF32]
-
-    # Test sensor API
-    sensor_list = sd.list_sensors(dev)
-    @test map(sensor -> sd.read_sensor(dev, sensor), sensor_list) == ["true", "1.0", "1.0"]
-    sensor_info_list = map(sensor -> sd.get_sensor_info(dev, sensor), sensor_list)
-
-
-    # test time API
-    time_sources = sd.list_time_sources(dev)
-    @test time_sources == ["sw_ticks", "hw_ticks"]
-    @test sd.get_time_source(dev) == "sw_ticks"
-    sd.set_time_source!(dev, "hw_ticks")
-    @test sd.get_time_source(dev) == "hw_ticks"
-
-
-
-
-    @show sd.list_sample_rates(rx_chan)
 
     #@test gainrange(rx_chan) == 0u"dB"..53u"dB"
     #@test gainrange(tx_chan) == 0u"dB"..53u"dB"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -61,10 +61,13 @@ end
     @test typeof(dev.info) == sd.OwnedKWArgs
     @test dev.driver == :LoopbackDriver
     @test dev.hardware == :LoopbackHardware
-    @test dev.timesources == SoapySDR.TimeSource[:sw_ticks,:hw_ticks] 
-    @test dev.timesource == SoapySDR.TimeSource(:sw_ticks)
-    dev.timesource = "hw_ticks"
-    @test dev.timesource == SoapySDR.TimeSource(:hw_ticks)
+    @test dev.time_sources == SoapySDR.TimeSource[:sw_ticks,:hw_ticks] 
+    @test dev.time_source == SoapySDR.TimeSource(:sw_ticks)
+    dev.time_source = "hw_ticks"
+    @test dev.time_source == SoapySDR.TimeSource(:hw_ticks)
+    dev.time_source = dev.time_sources[1]
+    @test dev.time_source == SoapySDR.TimeSource(:sw_ticks)
+
 
     # Channels
     rx_chan_list = dev.rx
@@ -97,7 +100,7 @@ end
     if1 = rx_chan.gain_elements[1]
     @show rx_chan[if1]
     rx_chan[if1] = 0.5u"dB"
-    @test rx_chan[if1] == 0.5u"dB"
+    @test_broken rx_chan[if1] == 0.5u"dB"
 
     #@show rx_chan.gain_profile
     @show rx_chan.frequency_correction

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -79,6 +79,8 @@ end
     @test typeof(tx_chan) == sd.Channel
     show(io, rx_chan)
     show(io, tx_chan)
+    show(io, MIME"text/plain"(), rx_chan)
+    show(io, MIME"text/plain"(), tx_chan)
 
     #channel set/get properties
     @test rx_chan.native_stream_format == SoapySDR.ComplexInt{12} #, fullscale
@@ -86,57 +88,17 @@ end
     @test tx_chan.native_stream_format == SoapySDR.ComplexInt{12} #, fullscale
     @test tx_chan.stream_formats == [Complex{Int8}, SoapySDR.ComplexInt{12}, Complex{Int16}, ComplexF32]
 
-    rx_chan.info
-    rx_chan.antenna
-    rx_chan.gain
-    rx_chan.dc_offset_mode
-    rx_chan.dc_offset
-    rx_chan.iq_balance_mode
-    rx_chan.iq_balance
-    rx_chan.gain_mode
-    rx_chan.frequency_correction
-    rx_chan.sample_rate
-    rx_chan.bandwidth
-    rx_chan.frequency
+    # channel gain tests
+    @test rx_chan.gain_mode == false
+    rx_chan.gain_mode = true
+    @test rx_chan.gain_mode == true
 
-    tx_chan.info
-    tx_chan.antenna
-    tx_chan.gain
-    tx_chan.dc_offset_mode
-    tx_chan.dc_offset
-    tx_chan.iq_balance_mode
-    tx_chan.iq_balance
-    tx_chan.gain_mode
-    tx_chan.frequency_correction
-    tx_chan.sample_rate
-    tx_chan.bandwidth
-    tx_chan.frequency
+    @test rx_chan.gain_elements == SoapySDR.GainElement[:IF1, :IF2, :IF3, :IF4, :IF5, :IF6, :TUNER]
+    if1 = rx_chan.gain_elements[1]
+    @show rx_chan[if1]
+    rx_chan[if1] = 0.5u"dB"
+    @test rx_chan[if1] == 0.5u"dB"
 
-
-    #@test gainrange(rx_chan) == 0u"dB"..53u"dB"
-    #@test gainrange(tx_chan) == 0u"dB"..53u"dB"
-    @show sd.frequency_ranges(rx_chan)
-    @show sd.frequency_ranges(tx_chan)
-    @show sd.bandwidth_ranges(rx_chan)
-    @show sd.bandwidth_ranges(tx_chan)
-    @show sd.sample_rate_ranges(rx_chan)
-    @show sd.sample_rate_ranges(tx_chan)
-
-    #@show sd.GainElement(rx_chan)
-    #@show sd.GainElement(tx_chan)
-
-    # Loopback initialized defaults
-    #@test rx_chan.bandwidth == 2.048e6u"Hz"
-    #@test rx_chan.frequency == 1.0e8u"Hz"
-    #@test rx_chan.gain == -53u"dB"
-    #@test rx_chan.sample_rate == 2.048e6u"Hz"
-    @show rx_chan.info
-    @show rx_chan.antenna
-    @show rx_chan.dc_offset_mode
-    @show rx_chan.dc_offset
-    @show rx_chan.iq_balance_mode
-    @show rx_chan.iq_balance
-    @show rx_chan.gain_mode
     #@show rx_chan.gain_profile
     @show rx_chan.frequency_correction
 


### PR DESCRIPTION
This follows the API that Keno setup. The main improvements are discovery (`propertynames`), improved printing, and using `<: Component` for `Device`s as well (e.g. clock, time, and sensors). 

TODO:

- [x] clock
- [x] reference clock
- [x] time
- [x] docs
- [x] more printing
- [x] naming audit

