### PR TITLE
Fix double-free when freeing `ArgInfoList` objects

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -165,7 +165,10 @@ end
     arglist = SoapySDR.ArgInfoList(SoapySDR.SoapySDRDevice_getSettingInfo(dev)...)
     println(arglist)
     a1 = arglist[1]
+    println(a1)
 end
+
+
 @testset "Examples" begin
     include("../examples/highlevel_dump_devices.jl")
 end


### PR DESCRIPTION
We previously used `StringList()` as a convenient way to print out the
options of an `ArgInfoList`, however `StringList()` by default assumes
that it owns the memory and should free it when the object is destroyed.
This conflicted with the `ArgInfoList`'s own cleanup.  This PR fixes the
issue by adding an `owned` keyword argument to `StringList` and using it
within the `show()` override.  It also includes a test that should
purposefully trigger the double-free, to prevent future regressions.