### PR TITLE
When opening a `Device`, check for NULL pointer

### DIFF
--- a/src/highlevel.jl
+++ b/src/highlevel.jl
@@ -61,6 +61,12 @@ Fields:
 """
 mutable struct Device
     ptr::Ptr{SoapySDRDevice}
+    function Device(dev_ptr)
+        if dev_ptr == C_NULL
+            throw(ArgumentError("Unable to open device!"))
+        end
+        return new(dev_ptr)
+    end
 end
 SoapySDRDevice_unmake(d::Device) = SoapySDRDevice_unmake(d.ptr)
 Base.cconvert(::Type{<:Ptr{SoapySDRDevice}}, d::Device) = d

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -71,6 +71,9 @@ end
 @testset "High Level API" begin
     io = IOBuffer(read=true, write=true)
 
+    # Test failing to open a device due to an invalid specification
+    @test_throws ArgumentError open(parse(KWArgs, "driver=foo"))
+
     # Device constructor, show, iterator
     @test length(Devices()) == 1
     show(io, Devices())


### PR DESCRIPTION
When we attempt to open a device, we should check to ensure that the
library does not return to us a NULL pointer.  If it does, we do not
then attempt to use it in future API calls, but must throw an error.