### PR TITLE
Change `activate!()` default to continuous stream, rather than burst

### DIFF
--- a/src/highlevel.jl
+++ b/src/highlevel.jl
@@ -686,8 +686,17 @@ function Base.read(s::Stream{T}, n::Integer; timeout=nothing) where {T}
 end
 
 function activate!(s::Stream; flags = 0, timens = nothing, numElems = nothing)
-    SoapySDRDevice_activateStream(s.d, s, flags, timens === nothing ? 0 : uconvert(u"ns", timens).val, numElems === nothing ? s.mtu : numElems)
-    nothing
+    if timens === nothing
+        timens = 0
+    else
+        timens = uconvert(u"ns", timens).val
+    end
+    if numElems === nothing
+        numElems = 0
+    end
+
+    SoapySDRDevice_activateStream(s.d, s, flags, timens, numElems)
+    return nothing
 end
 
 function deactivate!(s::Stream; flags = 0, timens = nothing)


### PR DESCRIPTION
By setting `numElems`, we set ourselves to "burst" mode, which will
cause the device to capture exactly `numElems` samples before stopping
the stream [0].  Not every device supports this mode of operation [1,2]
which is probably why this wasn't caught before.

We should instead use a default of `0`, which enables constant streaming
mode.

[0] https://github.com/myriadrf/LimeSuite/blob/a031622aa07c7614644a47d06f7b9e71ee4d385c/SoapyLMS7/Streaming.cpp#L435-L440
[1] https://github.com/pothosware/SoapyRTLSDR/blob/40d0708b009cac1a77f9a7c4052b2f3951b08f60/Streaming.cpp#L313
[2] https://github.com/JuliaComputing/xtrx_julia/blob/6d603e1043b3e5b612abfde99b6f8be1630f126f/software/soapysdr-xtrx/Streaming.cpp#L117