### PR TITLE
Check device/stream are open before `{read,write}Stream`

### DIFF
--- a/src/functionwraps.jl
+++ b/src/functionwraps.jl
@@ -111,6 +111,12 @@ function SoapySDRDevice_releaseWriteBuffer(device::Device, stream, handle, numEl
 end
 
 function SoapySDRDevice_readStream(device::Device, stream, buffs, numElems, timeoutUs)
+    if !isopen(device)
+        throw(InvalidStateException("device is closed!", :closed))
+    end
+    if !isopen(stream)
+        throw(InvalidStateException("stream is closed!", :closed))
+    end
     flags = Ref{Cint}()
     timeNs = Ref{Clonglong}()
     nelems = ccall((:SoapySDRDevice_readStream, lib), Cint, (Ptr{SoapySDRDevice}, Ptr{SoapySDRStream}, Ptr{Cvoid}, Csize_t, Ptr{Cint}, Ptr{Clonglong}, Clong),
@@ -119,6 +125,12 @@ function SoapySDRDevice_readStream(device::Device, stream, buffs, numElems, time
 end
 
 function SoapySDRDevice_writeStream(device::Device, stream, buffs, numElems, flags, timeNs, timeoutUs)
+    if !isopen(device)
+        throw(InvalidStateException("device is closed!", :closed))
+    end
+    if !isopen(stream)
+        throw(InvalidStateException("stream is closed!", :closed))
+    end
     flags = Ref{Cint}(flags)
     nelems = ccall((:SoapySDRDevice_writeStream, lib), Cint, (Ptr{SoapySDRDevice}, Ptr{SoapySDRStream}, Ptr{Cvoid}, Csize_t, Ptr{Cint}, Clonglong, Clong),
         device, stream, buffs, numElems, flags, timeNs, timeoutUs)

--- a/src/highlevel.jl
+++ b/src/highlevel.jl
@@ -68,6 +68,7 @@ mutable struct Device
         this = new(dev_ptr)
         finalizer(this) do this
             this.ptr != C_NULL && SoapySDRDevice_unmake(this.ptr)
+            this.ptr = Ptr{SoapySDRDevice}(C_NULL)
         end
         return this
     end
@@ -590,10 +591,12 @@ mutable struct Stream{T}
         finalizer(this) do obj
             isopen(d) || return
             SoapySDRDevice_closeStream(d, obj.ptr)
+            obj.ptr = Ptr{SoapySDRStream}(C_NULL)
         end
         return this
     end
 end
+
 Base.cconvert(::Type{<:Ptr{SoapySDRStream}}, s::Stream) = s
 Base.unsafe_convert(::Type{<:Ptr{SoapySDRStream}}, s::Stream) = s.ptr
 Base.isopen(s::Stream) = s.ptr != C_NULL

--- a/src/highlevel.jl
+++ b/src/highlevel.jl
@@ -658,6 +658,15 @@ function Stream(channel::Channel; kwargs...)
     Stream([channel], kwargs...)
 end
 
+function Stream(f::Function, args...; kwargs...)
+    stream = Stream(args...; kwargs...)
+    try
+        f(stream)
+    finally
+        finalize(stream)
+    end
+end
+
 """
     read!(s::SoapySDR.Stream{T}, buffer::NTuple{N, Vector{T}}; [timeout])
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -181,7 +181,10 @@ end
     end
     # and again to ensure correct GC
     Device(Devices()[1]) do dev
-        println(dev.info)
+        sd.Stream(ComplexF32, [dev.rx[1]]) do s_rx
+            println(dev.info)
+            println(s_rx)
+        end
     end
 end
 @testset "Settings" begin


### PR DESCRIPTION
It's best to ensure that a given device or stream is open before
attempting to read/write to it.  This is especially important in the
event that you are doing something like:

```
Device(...) do dev
   @async read_loop(dev)
   ...
end
```

In the event that an exception is triggered, the `Device` will be
cleaned up by the `do`-block `Device` method, and the asynchronous
`read_loop()` will very quickly attempt to read from the now-defunct
`Device` object.  This segfaults, often bringing the process down before
the original exception has had a chance to print out.

This PR changes the behavior to instead pay a miniscule cost each time
we attempt to use the `Device` and `Stream` objects, translating
segfaults to exceptions.