### PR TITLE
Add error checking to all `SoapySDRDevice_` calls

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "4fa426e6-03fd-45b2-b2dd-25f726820c03"
 keywords = ["sdr", "software defined radio", "radio"]
 license = "Boost"
 desc = "Bindings to the SoapySDR library."
-version = "0.3.3"
+version = "0.3.4"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"

--- a/src/SoapySDR.jl
+++ b/src/SoapySDR.jl
@@ -13,6 +13,7 @@ const GC = Base.GC
 
 export @u_str
 
+include("error.jl")
 include("lowlevel/auto_wrap.jl")
 include("unithelpers.jl")
 include("typemap.jl")
@@ -21,7 +22,6 @@ include("highlevel.jl")
 include("functionwraps.jl")
 include("logger.jl")
 include("version.jl")
-include("error.jl")
 include("Modules.jl")
 
 const SDRStream = Stream

--- a/src/functionwraps.jl
+++ b/src/functionwraps.jl
@@ -83,6 +83,9 @@ function SoapySDRDevice_acquireReadBuffer(device::Device, stream, buffs, timeout
     handle = Ref{Csize_t}()
     flags = Ref{Cint}(0)
     timeNs = Ref{Clonglong}(-1)
+    if !isopen(stream)
+        throw(InvalidStateException("stream is closed!", :closed))
+    end
     bytes = SoapySDRDevice_acquireReadBuffer(device, stream, handle, buffs, flags, timeNs, timeoutUs)
     bytes, handle[], flags[], timeNs[]
 end
@@ -94,6 +97,9 @@ function SoapySDRDevice_acquireWriteBuffer(device::Device, stream, buffs, timeou
     #    void **buffs,
     #    const long timeoutUs);
     handle = Ref{Csize_t}()
+    if !isopen(stream)
+        throw(InvalidStateException("stream is closed!", :closed))
+    end
     bytes = SoapySDRDevice_acquireWriteBuffer(device, stream, handle, buffs, timeoutUs)
     return bytes, handle[]
 end

--- a/src/highlevel.jl
+++ b/src/highlevel.jl
@@ -19,7 +19,7 @@ Devices(driver="rtlsdr")
 """
 struct Devices
     kwargslist::KWArgsList
-    function Devices(args=nothing)
+    function Devices(args)
         len = Ref{Csize_t}()
         kwargs = SoapySDRDevice_enumerate(isnothing(args) ? C_NULL : args, len)
         kwargs = KWArgsList(kwargs, len[])

--- a/src/highlevel.jl
+++ b/src/highlevel.jl
@@ -695,6 +695,25 @@ function Stream(f::Function, args...; kwargs...)
     end
 end
 
+const SoapyStreamFlags = Dict(
+    "END_BURST" => SOAPY_SDR_END_BURST,
+    "HAS_TIME" => SOAPY_SDR_HAS_TIME,
+    "END_ABRUPT" => SOAPY_SDR_END_ABRUPT,
+    "ONE_PACKET" => SOAPY_SDR_ONE_PACKET,
+    "MORE_FRAGMENTS" => SOAPY_SDR_MORE_FRAGMENTS,
+    "WAIT_TRIGGER" => SOAPY_SDR_WAIT_TRIGGER,
+)
+
+function flags_to_set(flags)
+    s = Set{String}()
+    for (name, val) in SoapyStreamFlags
+        if val & flags != 0
+            push!(s, name)
+        end
+    end
+    return s
+end
+
 """
     read!(s::SoapySDR.Stream{T}, buffers::NTuple{N, Vector{T}}; [timeout])
 

--- a/src/lowlevel/auto_wrap.jl
+++ b/src/lowlevel/auto_wrap.jl
@@ -141,7 +141,7 @@ Enumerate a list of available devices on the system.
 \\return a list of arguments strings, each unique to a device
 """
 function SoapySDRDevice_enumerate(args, length)
-    ccall((:SoapySDRDevice_enumerate, soapysdr), Ptr{SoapySDRKwargs}, (Ptr{SoapySDRKwargs}, Ptr{Csize_t}), args, length)
+    @soapy_checked ccall((:SoapySDRDevice_enumerate, soapysdr), Ptr{SoapySDRKwargs}, (Ptr{SoapySDRKwargs}, Ptr{Csize_t}), args, length)
 end
 
 """
@@ -154,7 +154,7 @@ Markup format for args: "keyA=valA, keyB=valB".
 \\return a list of arguments strings, each unique to a device
 """
 function SoapySDRDevice_enumerateStrArgs(args, length)
-    ccall((:SoapySDRDevice_enumerateStrArgs, soapysdr), Ptr{SoapySDRKwargs}, (Ptr{Cchar}, Ptr{Csize_t}), args, length)
+    @soapy_checked ccall((:SoapySDRDevice_enumerateStrArgs, soapysdr), Ptr{SoapySDRKwargs}, (Ptr{Cchar}, Ptr{Csize_t}), args, length)
 end
 
 """
@@ -169,7 +169,7 @@ For every call to make, there should be a matched call to unmake.
 \\return a pointer to a new Device object
 """
 function SoapySDRDevice_make(args)
-    ccall((:SoapySDRDevice_make, soapysdr), Ptr{SoapySDRDevice}, (Ptr{SoapySDRKwargs},), args)
+    @soapy_checked ccall((:SoapySDRDevice_make, soapysdr), Ptr{SoapySDRDevice}, (Ptr{SoapySDRKwargs},), args)
 end
 
 """
@@ -184,7 +184,7 @@ For every call to make, there should be a matched call to unmake.
 \\return a pointer to a new Device object or null for error
 """
 function SoapySDRDevice_makeStrArgs(args)
-    ccall((:SoapySDRDevice_makeStrArgs, soapysdr), Ptr{SoapySDRDevice}, (Ptr{Cchar},), args)
+    @soapy_checked ccall((:SoapySDRDevice_makeStrArgs, soapysdr), Ptr{SoapySDRDevice}, (Ptr{Cchar},), args)
 end
 
 """
@@ -196,7 +196,7 @@ Unmake or release a device object handle.
 \\return 0 for success or error code on failure
 """
 function SoapySDRDevice_unmake(device)
-    ccall((:SoapySDRDevice_unmake, soapysdr), Cint, (Ptr{SoapySDRDevice},), device)
+    @soapy_checked ccall((:SoapySDRDevice_unmake, soapysdr), Cint, (Ptr{SoapySDRDevice},), device)
 end
 
 """
@@ -211,7 +211,7 @@ and is fundamentally a parallel for loop of make(Kwargs).
 \\return a list of device pointers per each specified argument
 """
 function SoapySDRDevice_make_list(argsList, length)
-    ccall((:SoapySDRDevice_make_list, soapysdr), Ptr{Ptr{SoapySDRDevice}}, (Ptr{SoapySDRKwargs}, Csize_t), argsList, length)
+    @soapy_checked ccall((:SoapySDRDevice_make_list, soapysdr), Ptr{Ptr{SoapySDRDevice}}, (Ptr{SoapySDRKwargs}, Csize_t), argsList, length)
 end
 
 """
@@ -226,7 +226,7 @@ and is fundamentally a parallel for loop of makeStrArgs(args).
 \\return a list of device pointers per each specified argument
 """
 function SoapySDRDevice_make_listStrArgs(argsList, length)
-    ccall((:SoapySDRDevice_make_listStrArgs, soapysdr), Ptr{Ptr{SoapySDRDevice}}, (Ptr{Ptr{Cchar}}, Csize_t), argsList, length)
+    @soapy_checked ccall((:SoapySDRDevice_make_listStrArgs, soapysdr), Ptr{Ptr{SoapySDRDevice}}, (Ptr{Ptr{Cchar}}, Csize_t), argsList, length)
 end
 
 """
@@ -242,7 +242,7 @@ and is fundamentally a parallel for loop of unmake(Device *).
 \\return 0 for success or error code on failure
 """
 function SoapySDRDevice_unmake_list(devices, length)
-    ccall((:SoapySDRDevice_unmake_list, soapysdr), Cint, (Ptr{Ptr{SoapySDRDevice}}, Csize_t), devices, length)
+    @soapy_checked ccall((:SoapySDRDevice_unmake_list, soapysdr), Cint, (Ptr{Ptr{SoapySDRDevice}}, Csize_t), devices, length)
 end
 
 """
@@ -254,7 +254,7 @@ Several variants of a product may share a driver.
 \\param device a pointer to a device instance
 """
 function SoapySDRDevice_getDriverKey(device)
-    ccall((:SoapySDRDevice_getDriverKey, soapysdr), Ptr{Cchar}, (Ptr{SoapySDRDevice},), device)
+    @soapy_checked ccall((:SoapySDRDevice_getDriverKey, soapysdr), Ptr{Cchar}, (Ptr{SoapySDRDevice},), device)
 end
 
 """
@@ -269,7 +269,7 @@ function SoapySDRDevice_getHardwareKey(device)
     if !isopen(device)
         throw(InvalidStateException("Device is closed!", :closed))
     end
-    ccall((:SoapySDRDevice_getHardwareKey, soapysdr), Ptr{Cchar}, (Ptr{SoapySDRDevice},), device)
+    @soapy_checked ccall((:SoapySDRDevice_getHardwareKey, soapysdr), Ptr{Cchar}, (Ptr{SoapySDRDevice},), device)
 end
 
 """
@@ -283,7 +283,7 @@ to help identify the instantiated device.
 \\param device a pointer to a device instance
 """
 function SoapySDRDevice_getHardwareInfo(device)
-    ccall((:SoapySDRDevice_getHardwareInfo, soapysdr), SoapySDRKwargs, (Ptr{SoapySDRDevice},), device)
+    @soapy_checked ccall((:SoapySDRDevice_getHardwareInfo, soapysdr), SoapySDRKwargs, (Ptr{SoapySDRDevice},), device)
 end
 
 """
@@ -297,7 +297,7 @@ This mapping controls channel mapping and channel availability.
 \\return an error code or 0 for success
 """
 function SoapySDRDevice_setFrontendMapping(device, direction, mapping)
-    ccall((:SoapySDRDevice_setFrontendMapping, soapysdr), Cint, (Ptr{SoapySDRDevice}, Cint, Ptr{Cchar}), device, direction, mapping)
+    @soapy_checked ccall((:SoapySDRDevice_setFrontendMapping, soapysdr), Cint, (Ptr{SoapySDRDevice}, Cint, Ptr{Cchar}), device, direction, mapping)
 end
 
 """
@@ -309,7 +309,7 @@ Get the mapping configuration string.
 \\return the vendor-specific mapping string
 """
 function SoapySDRDevice_getFrontendMapping(device, direction)
-    ccall((:SoapySDRDevice_getFrontendMapping, soapysdr), Ptr{Cchar}, (Ptr{SoapySDRDevice}, Cint), device, direction)
+    @soapy_checked ccall((:SoapySDRDevice_getFrontendMapping, soapysdr), Ptr{Cchar}, (Ptr{SoapySDRDevice}, Cint), device, direction)
 end
 
 """
@@ -321,7 +321,7 @@ Get a number of channels given the streaming direction
 \\return the number of channels
 """
 function SoapySDRDevice_getNumChannels(device, direction)
-    ccall((:SoapySDRDevice_getNumChannels, soapysdr), Csize_t, (Ptr{SoapySDRDevice}, Cint), device, direction)
+    @soapy_checked ccall((:SoapySDRDevice_getNumChannels, soapysdr), Csize_t, (Ptr{SoapySDRDevice}, Cint), device, direction)
 end
 
 """
@@ -334,7 +334,7 @@ Get channel info given the streaming direction
 \\return channel information
 """
 function SoapySDRDevice_getChannelInfo(device, direction, channel)
-    ccall((:SoapySDRDevice_getChannelInfo, soapysdr), SoapySDRKwargs, (Ptr{SoapySDRDevice}, Cint, Csize_t), device, direction, channel)
+    @soapy_checked ccall((:SoapySDRDevice_getChannelInfo, soapysdr), SoapySDRKwargs, (Ptr{SoapySDRDevice}, Cint, Csize_t), device, direction, channel)
 end
 
 """
@@ -347,7 +347,7 @@ Find out if the specified channel is full or half duplex.
 \\return true for full duplex, false for half duplex
 """
 function SoapySDRDevice_getFullDuplex(device, direction, channel)
-    ccall((:SoapySDRDevice_getFullDuplex, soapysdr), Bool, (Ptr{SoapySDRDevice}, Cint, Csize_t), device, direction, channel)
+    @soapy_checked ccall((:SoapySDRDevice_getFullDuplex, soapysdr), Bool, (Ptr{SoapySDRDevice}, Cint, Csize_t), device, direction, channel)
 end
 
 """
@@ -362,7 +362,7 @@ Query a list of the available stream formats.
  See SoapySDRDevice_setupStream() for the format syntax.
 """
 function SoapySDRDevice_getStreamFormats(device, direction, channel, length)
-    ccall((:SoapySDRDevice_getStreamFormats, soapysdr), Ptr{Ptr{Cchar}}, (Ptr{SoapySDRDevice}, Cint, Csize_t, Ptr{Csize_t}), device, direction, channel, length)
+    @soapy_checked ccall((:SoapySDRDevice_getStreamFormats, soapysdr), Ptr{Ptr{Cchar}}, (Ptr{SoapySDRDevice}, Cint, Csize_t, Ptr{Csize_t}), device, direction, channel, length)
 end
 
 """
@@ -378,7 +378,7 @@ and the direct buffer access API calls (when available).
 \\return the native stream buffer format string
 """
 function SoapySDRDevice_getNativeStreamFormat(device, direction, channel, fullScale)
-    ccall((:SoapySDRDevice_getNativeStreamFormat, soapysdr), Ptr{Cchar}, (Ptr{SoapySDRDevice}, Cint, Csize_t, Ptr{Cdouble}), device, direction, channel, fullScale)
+    @soapy_checked ccall((:SoapySDRDevice_getNativeStreamFormat, soapysdr), Ptr{Cchar}, (Ptr{SoapySDRDevice}, Cint, Csize_t, Ptr{Cdouble}), device, direction, channel, fullScale)
 end
 
 """
@@ -433,7 +433,7 @@ Query the argument info description for stream args.
 \\return a list of argument info structures
 """
 function SoapySDRDevice_getStreamArgsInfo(device, direction, channel, length)
-    ccall((:SoapySDRDevice_getStreamArgsInfo, soapysdr), Ptr{SoapySDRArgInfo}, (Ptr{SoapySDRDevice}, Cint, Csize_t, Ptr{Csize_t}), device, direction, channel, length)
+    @soapy_checked ccall((:SoapySDRDevice_getStreamArgsInfo, soapysdr), Ptr{SoapySDRArgInfo}, (Ptr{SoapySDRDevice}, Cint, Csize_t, Ptr{Csize_t}), device, direction, channel, length)
 end
 
 """
@@ -492,7 +492,7 @@ The type character is followed by the number of bits per number (complex is 2x t
 \\return the stream pointer or nullptr for failure
 """
 function SoapySDRDevice_setupStream(device, direction, format, channels, numChans, args)
-    ccall((:SoapySDRDevice_setupStream, soapysdr), Ptr{SoapySDRStream}, (Ptr{SoapySDRDevice}, Cint, Ptr{Cchar}, Ptr{Csize_t}, Csize_t, Ptr{SoapySDRKwargs}), device, direction, format, channels, numChans, args)
+    @soapy_checked ccall((:SoapySDRDevice_setupStream, soapysdr), Ptr{SoapySDRStream}, (Ptr{SoapySDRDevice}, Cint, Ptr{Cchar}, Ptr{Csize_t}, Csize_t, Ptr{SoapySDRKwargs}), device, direction, format, channels, numChans, args)
 end
 
 """
@@ -504,7 +504,7 @@ Close an open stream created by setupStream
 \\return 0 for success or error code on failure
 """
 function SoapySDRDevice_closeStream(device, stream)
-    ccall((:SoapySDRDevice_closeStream, soapysdr), Cint, (Ptr{SoapySDRDevice}, Ptr{SoapySDRStream}), device, stream)
+    @soapy_checked ccall((:SoapySDRDevice_closeStream, soapysdr), Cint, (Ptr{SoapySDRDevice}, Ptr{SoapySDRStream}), device, stream)
 end
 
 """
@@ -520,7 +520,7 @@ best optimize throughput given the underlying stream implementation.
 \\return the MTU in number of stream elements (never zero)
 """
 function SoapySDRDevice_getStreamMTU(device, stream)
-    ccall((:SoapySDRDevice_getStreamMTU, soapysdr), Csize_t, (Ptr{SoapySDRDevice}, Ptr{SoapySDRStream}), device, stream)
+    @soapy_checked ccall((:SoapySDRDevice_getStreamMTU, soapysdr), Csize_t, (Ptr{SoapySDRDevice}, Ptr{SoapySDRStream}), device, stream)
 end
 
 """
@@ -544,7 +544,7 @@ In this case, the implementation returns SOAPY_SDR_NOT_SUPPORTED.
 \\return 0 for success or error code on failure
 """
 function SoapySDRDevice_activateStream(device, stream, flags, timeNs, numElems)
-    ccall((:SoapySDRDevice_activateStream, soapysdr), Cint, (Ptr{SoapySDRDevice}, Ptr{SoapySDRStream}, Cint, Clonglong, Csize_t), device, stream, flags, timeNs, numElems)
+    @soapy_checked ccall((:SoapySDRDevice_activateStream, soapysdr), Cint, (Ptr{SoapySDRDevice}, Ptr{SoapySDRStream}, Cint, Clonglong, Csize_t), device, stream, flags, timeNs, numElems)
 end
 
 """
@@ -568,7 +568,7 @@ function SoapySDRDevice_deactivateStream(device, stream, flags, timeNs)
     if !isopen(stream)
         throw(InvalidStateException("Stream is closed!", :closed))
     end
-    ccall((:SoapySDRDevice_deactivateStream, soapysdr), Cint, (Ptr{SoapySDRDevice}, Ptr{SoapySDRStream}, Cint, Clonglong), device, stream, flags, timeNs)
+    @soapy_checked ccall((:SoapySDRDevice_deactivateStream, soapysdr), Cint, (Ptr{SoapySDRDevice}, Ptr{SoapySDRStream}, Cint, Clonglong), device, stream, flags, timeNs)
 end
 
 """
@@ -594,7 +594,7 @@ specified by the caller and return SOAPY_SDR_TIMEOUT.
 \\return the number of elements read per buffer or error code
 """
 function SoapySDRDevice_readStream(device, stream, buffs, numElems, flags, timeNs, timeoutUs)
-    ccall((:SoapySDRDevice_readStream, soapysdr), Cint, (Ptr{SoapySDRDevice}, Ptr{SoapySDRStream}, Ptr{Ptr{Cvoid}}, Csize_t, Ptr{Cint}, Ptr{Clonglong}, Clong), device, stream, buffs, numElems, flags, timeNs, timeoutUs)
+    @soapy_checked ccall((:SoapySDRDevice_readStream, soapysdr), Cint, (Ptr{SoapySDRDevice}, Ptr{SoapySDRStream}, Ptr{Ptr{Cvoid}}, Csize_t, Ptr{Cint}, Ptr{Clonglong}, Clong), device, stream, buffs, numElems, flags, timeNs, timeoutUs)
 end
 
 """
@@ -620,7 +620,7 @@ or timeout expiration.
 \\return the number of elements written per buffer or error
 """
 function SoapySDRDevice_writeStream(device, stream, buffs, numElems, flags, timeNs, timeoutUs)
-    ccall((:SoapySDRDevice_writeStream, soapysdr), Cint, (Ptr{SoapySDRDevice}, Ptr{SoapySDRStream}, Ptr{Ptr{Cvoid}}, Csize_t, Ptr{Cint}, Clonglong, Clong), device, stream, buffs, numElems, flags, timeNs, timeoutUs)
+    @soapy_checked ccall((:SoapySDRDevice_writeStream, soapysdr), Cint, (Ptr{SoapySDRDevice}, Ptr{SoapySDRStream}, Ptr{Ptr{Cvoid}}, Csize_t, Ptr{Cint}, Clonglong, Clong), device, stream, buffs, numElems, flags, timeNs, timeoutUs)
 end
 
 """
@@ -647,7 +647,7 @@ Client code may use this indication to disable a polling loop.
 \\return 0 for success or error code like timeout
 """
 function SoapySDRDevice_readStreamStatus(device, stream, chanMask, flags, timeNs, timeoutUs)
-    ccall((:SoapySDRDevice_readStreamStatus, soapysdr), Cint, (Ptr{SoapySDRDevice}, Ptr{SoapySDRStream}, Ptr{Csize_t}, Ptr{Cint}, Ptr{Clonglong}, Clong), device, stream, chanMask, flags, timeNs, timeoutUs)
+    @soapy_checked ccall((:SoapySDRDevice_readStreamStatus, soapysdr), Cint, (Ptr{SoapySDRDevice}, Ptr{SoapySDRStream}, Ptr{Csize_t}, Ptr{Cint}, Ptr{Clonglong}, Clong), device, stream, chanMask, flags, timeNs, timeoutUs)
 end
 
 """
@@ -663,7 +663,7 @@ A return value of 0 means that direct access is not supported.
 \\return the number of direct access buffers or 0
 """
 function SoapySDRDevice_getNumDirectAccessBuffers(device, stream)
-    ccall((:SoapySDRDevice_getNumDirectAccessBuffers, soapysdr), Csize_t, (Ptr{SoapySDRDevice}, Ptr{SoapySDRStream}), device, stream)
+    @soapy_checked ccall((:SoapySDRDevice_getNumDirectAccessBuffers, soapysdr), Csize_t, (Ptr{SoapySDRDevice}, Ptr{SoapySDRStream}), device, stream)
 end
 
 """
@@ -683,7 +683,7 @@ after stream creation to pre-allocate a re-usable ring-buffer.
 \\return 0 for success or error code when not supported
 """
 function SoapySDRDevice_getDirectAccessBufferAddrs(device, stream, handle, buffs)
-    ccall((:SoapySDRDevice_getDirectAccessBufferAddrs, soapysdr), Cint, (Ptr{SoapySDRDevice}, Ptr{SoapySDRStream}, Csize_t, Ptr{Ptr{Cvoid}}), device, stream, handle, buffs)
+    @soapy_checked ccall((:SoapySDRDevice_getDirectAccessBufferAddrs, soapysdr), Cint, (Ptr{SoapySDRDevice}, Ptr{SoapySDRStream}, Csize_t, Ptr{Ptr{Cvoid}}), device, stream, handle, buffs)
 end
 
 """
@@ -710,7 +710,7 @@ such that handle is between 0 and num direct buffers - 1.
 \\return the number of elements read per buffer or error code
 """
 function SoapySDRDevice_acquireReadBuffer(device, stream, handle, buffs, flags, timeNs, timeoutUs)
-    ccall((:SoapySDRDevice_acquireReadBuffer, soapysdr), Cint, (Ptr{SoapySDRDevice}, Ptr{SoapySDRStream}, Ptr{Csize_t}, Ptr{Ptr{Cvoid}}, Ptr{Cint}, Ptr{Clonglong}, Clong), device, stream, handle, buffs, flags, timeNs, timeoutUs)
+    @soapy_checked ccall((:SoapySDRDevice_acquireReadBuffer, soapysdr), Cint, (Ptr{SoapySDRDevice}, Ptr{SoapySDRStream}, Ptr{Csize_t}, Ptr{Ptr{Cvoid}}, Ptr{Cint}, Ptr{Clonglong}, Clong), device, stream, handle, buffs, flags, timeNs, timeoutUs)
 end
 
 """
@@ -724,7 +724,7 @@ This call is part of the direct buffer access API.
 \\param handle the opaque handle from the acquire() call
 """
 function SoapySDRDevice_releaseReadBuffer(device, stream, handle)
-    ccall((:SoapySDRDevice_releaseReadBuffer, soapysdr), Cvoid, (Ptr{SoapySDRDevice}, Ptr{SoapySDRStream}, Csize_t), device, stream, handle)
+    @soapy_checked ccall((:SoapySDRDevice_releaseReadBuffer, soapysdr), Cvoid, (Ptr{SoapySDRDevice}, Ptr{SoapySDRStream}, Csize_t), device, stream, handle)
 end
 
 """
@@ -749,7 +749,7 @@ such that handle is between 0 and num direct buffers - 1.
 \\return the number of available elements per buffer or error
 """
 function SoapySDRDevice_acquireWriteBuffer(device, stream, handle, buffs, timeoutUs)
-    ccall((:SoapySDRDevice_acquireWriteBuffer, soapysdr), Cint, (Ptr{SoapySDRDevice}, Ptr{SoapySDRStream}, Ptr{Csize_t}, Ptr{Ptr{Cvoid}}, Clong), device, stream, handle, buffs, timeoutUs)
+    @soapy_checked ccall((:SoapySDRDevice_acquireWriteBuffer, soapysdr), Cint, (Ptr{SoapySDRDevice}, Ptr{SoapySDRStream}, Ptr{Csize_t}, Ptr{Ptr{Cvoid}}, Clong), device, stream, handle, buffs, timeoutUs)
 end
 
 """
@@ -771,7 +771,7 @@ which can be determined by the user as the buffers are filled.
 \\param timeNs the buffer's timestamp in nanoseconds
 """
 function SoapySDRDevice_releaseWriteBuffer(device, stream, handle, numElems, flags, timeNs)
-    ccall((:SoapySDRDevice_releaseWriteBuffer, soapysdr), Cvoid, (Ptr{SoapySDRDevice}, Ptr{SoapySDRStream}, Csize_t, Csize_t, Ptr{Cint}, Clonglong), device, stream, handle, numElems, flags, timeNs)
+    @soapy_checked ccall((:SoapySDRDevice_releaseWriteBuffer, soapysdr), Cvoid, (Ptr{SoapySDRDevice}, Ptr{SoapySDRStream}, Csize_t, Csize_t, Ptr{Cint}, Clonglong), device, stream, handle, numElems, flags, timeNs)
 end
 
 """
@@ -785,7 +785,7 @@ Get a list of available antennas to select on a given chain.
 \\return a list of available antenna names
 """
 function SoapySDRDevice_listAntennas(device, direction, channel, length)
-    ccall((:SoapySDRDevice_listAntennas, soapysdr), Ptr{Ptr{Cchar}}, (Ptr{SoapySDRDevice}, Cint, Csize_t, Ptr{Csize_t}), device, direction, channel, length)
+    @soapy_checked ccall((:SoapySDRDevice_listAntennas, soapysdr), Ptr{Ptr{Cchar}}, (Ptr{SoapySDRDevice}, Cint, Csize_t, Ptr{Csize_t}), device, direction, channel, length)
 end
 
 """
@@ -799,7 +799,7 @@ Set the selected antenna on a chain.
 \\return an error code or 0 for success
 """
 function SoapySDRDevice_setAntenna(device, direction, channel, name)
-    ccall((:SoapySDRDevice_setAntenna, soapysdr), Cint, (Ptr{SoapySDRDevice}, Cint, Csize_t, Ptr{Cchar}), device, direction, channel, name)
+    @soapy_checked ccall((:SoapySDRDevice_setAntenna, soapysdr), Cint, (Ptr{SoapySDRDevice}, Cint, Csize_t, Ptr{Cchar}), device, direction, channel, name)
 end
 
 """
@@ -812,7 +812,7 @@ Get the selected antenna on a chain.
 \\return the name of an available antenna
 """
 function SoapySDRDevice_getAntenna(device, direction, channel)
-    ccall((:SoapySDRDevice_getAntenna, soapysdr), Ptr{Cchar}, (Ptr{SoapySDRDevice}, Cint, Csize_t), device, direction, channel)
+    @soapy_checked ccall((:SoapySDRDevice_getAntenna, soapysdr), Ptr{Cchar}, (Ptr{SoapySDRDevice}, Cint, Csize_t), device, direction, channel)
 end
 
 """
@@ -825,7 +825,7 @@ Does the device support automatic DC offset corrections?
 \\return true if automatic corrections are supported
 """
 function SoapySDRDevice_hasDCOffsetMode(device, direction, channel)
-    ccall((:SoapySDRDevice_hasDCOffsetMode, soapysdr), Bool, (Ptr{SoapySDRDevice}, Cint, Csize_t), device, direction, channel)
+    @soapy_checked ccall((:SoapySDRDevice_hasDCOffsetMode, soapysdr), Bool, (Ptr{SoapySDRDevice}, Cint, Csize_t), device, direction, channel)
 end
 
 """
@@ -839,7 +839,7 @@ Set the automatic DC offset corrections mode.
 \\return an error code or 0 for success
 """
 function SoapySDRDevice_setDCOffsetMode(device, direction, channel, automatic)
-    ccall((:SoapySDRDevice_setDCOffsetMode, soapysdr), Cint, (Ptr{SoapySDRDevice}, Cint, Csize_t, Bool), device, direction, channel, automatic)
+    @soapy_checked ccall((:SoapySDRDevice_setDCOffsetMode, soapysdr), Cint, (Ptr{SoapySDRDevice}, Cint, Csize_t, Bool), device, direction, channel, automatic)
 end
 
 """
@@ -852,7 +852,7 @@ Get the automatic DC offset corrections mode.
 \\return true for automatic offset correction
 """
 function SoapySDRDevice_getDCOffsetMode(device, direction, channel)
-    ccall((:SoapySDRDevice_getDCOffsetMode, soapysdr), Bool, (Ptr{SoapySDRDevice}, Cint, Csize_t), device, direction, channel)
+    @soapy_checked ccall((:SoapySDRDevice_getDCOffsetMode, soapysdr), Bool, (Ptr{SoapySDRDevice}, Cint, Csize_t), device, direction, channel)
 end
 
 """
@@ -865,7 +865,7 @@ Does the device support frontend DC offset correction?
 \\return true if DC offset corrections are supported
 """
 function SoapySDRDevice_hasDCOffset(device, direction, channel)
-    ccall((:SoapySDRDevice_hasDCOffset, soapysdr), Bool, (Ptr{SoapySDRDevice}, Cint, Csize_t), device, direction, channel)
+    @soapy_checked ccall((:SoapySDRDevice_hasDCOffset, soapysdr), Bool, (Ptr{SoapySDRDevice}, Cint, Csize_t), device, direction, channel)
 end
 
 """
@@ -880,7 +880,7 @@ Set the frontend DC offset correction.
 \\return an error code or 0 for success
 """
 function SoapySDRDevice_setDCOffset(device, direction, channel, offsetI, offsetQ)
-    ccall((:SoapySDRDevice_setDCOffset, soapysdr), Cint, (Ptr{SoapySDRDevice}, Cint, Csize_t, Cdouble, Cdouble), device, direction, channel, offsetI, offsetQ)
+    @soapy_checked ccall((:SoapySDRDevice_setDCOffset, soapysdr), Cint, (Ptr{SoapySDRDevice}, Cint, Csize_t, Cdouble, Cdouble), device, direction, channel, offsetI, offsetQ)
 end
 
 """
@@ -895,7 +895,7 @@ Get the frontend DC offset correction.
 \\return 0 for success or error code on failure
 """
 function SoapySDRDevice_getDCOffset(device, direction, channel, offsetI, offsetQ)
-    ccall((:SoapySDRDevice_getDCOffset, soapysdr), Cint, (Ptr{SoapySDRDevice}, Cint, Csize_t, Ptr{Cdouble}, Ptr{Cdouble}), device, direction, channel, offsetI, offsetQ)
+    @soapy_checked ccall((:SoapySDRDevice_getDCOffset, soapysdr), Cint, (Ptr{SoapySDRDevice}, Cint, Csize_t, Ptr{Cdouble}, Ptr{Cdouble}), device, direction, channel, offsetI, offsetQ)
 end
 
 """
@@ -908,7 +908,7 @@ Does the device support frontend IQ balance correction?
 \\return true if IQ balance corrections are supported
 """
 function SoapySDRDevice_hasIQBalance(device, direction, channel)
-    ccall((:SoapySDRDevice_hasIQBalance, soapysdr), Bool, (Ptr{SoapySDRDevice}, Cint, Csize_t), device, direction, channel)
+    @soapy_checked ccall((:SoapySDRDevice_hasIQBalance, soapysdr), Bool, (Ptr{SoapySDRDevice}, Cint, Csize_t), device, direction, channel)
 end
 
 """
@@ -923,7 +923,7 @@ Set the frontend IQ balance correction.
 \\return an error code or 0 for success
 """
 function SoapySDRDevice_setIQBalance(device, direction, channel, balanceI, balanceQ)
-    ccall((:SoapySDRDevice_setIQBalance, soapysdr), Cint, (Ptr{SoapySDRDevice}, Cint, Csize_t, Cdouble, Cdouble), device, direction, channel, balanceI, balanceQ)
+    @soapy_checked ccall((:SoapySDRDevice_setIQBalance, soapysdr), Cint, (Ptr{SoapySDRDevice}, Cint, Csize_t, Cdouble, Cdouble), device, direction, channel, balanceI, balanceQ)
 end
 
 """
@@ -938,7 +938,7 @@ Get the frontend IQ balance correction.
 \\return 0 for success or error code on failure
 """
 function SoapySDRDevice_getIQBalance(device, direction, channel, balanceI, balanceQ)
-    ccall((:SoapySDRDevice_getIQBalance, soapysdr), Cint, (Ptr{SoapySDRDevice}, Cint, Csize_t, Ptr{Cdouble}, Ptr{Cdouble}), device, direction, channel, balanceI, balanceQ)
+    @soapy_checked ccall((:SoapySDRDevice_getIQBalance, soapysdr), Cint, (Ptr{SoapySDRDevice}, Cint, Csize_t, Ptr{Cdouble}, Ptr{Cdouble}), device, direction, channel, balanceI, balanceQ)
 end
 
 """
@@ -951,7 +951,7 @@ Does the device support automatic frontend IQ balance correction?
 \\return true if automatic IQ balance corrections are supported
 """
 function SoapySDRDevice_hasIQBalanceMode(device, direction, channel)
-    ccall((:SoapySDRDevice_hasIQBalanceMode, soapysdr), Bool, (Ptr{SoapySDRDevice}, Cint, Csize_t), device, direction, channel)
+    @soapy_checked ccall((:SoapySDRDevice_hasIQBalanceMode, soapysdr), Bool, (Ptr{SoapySDRDevice}, Cint, Csize_t), device, direction, channel)
 end
 
 """
@@ -965,7 +965,7 @@ Set the automatic frontend IQ balance correction.
 \\return 0 for success or error code on failure
 """
 function SoapySDRDevice_setIQBalanceMode(device, direction, channel, automatic)
-    ccall((:SoapySDRDevice_setIQBalanceMode, soapysdr), Cint, (Ptr{SoapySDRDevice}, Cint, Csize_t, Bool), device, direction, channel, automatic)
+    @soapy_checked ccall((:SoapySDRDevice_setIQBalanceMode, soapysdr), Cint, (Ptr{SoapySDRDevice}, Cint, Csize_t, Bool), device, direction, channel, automatic)
 end
 
 """
@@ -978,7 +978,7 @@ Get the automatic frontend IQ balance corrections mode.
 \\return true for automatic correction
 """
 function SoapySDRDevice_getIQBalanceMode(device, direction, channel)
-    ccall((:SoapySDRDevice_getIQBalanceMode, soapysdr), Bool, (Ptr{SoapySDRDevice}, Cint, Csize_t), device, direction, channel)
+    @soapy_checked ccall((:SoapySDRDevice_getIQBalanceMode, soapysdr), Bool, (Ptr{SoapySDRDevice}, Cint, Csize_t), device, direction, channel)
 end
 
 """
@@ -991,7 +991,7 @@ Does the device support frontend frequency correction?
 \\return true if frequency corrections are supported
 """
 function SoapySDRDevice_hasFrequencyCorrection(device, direction, channel)
-    ccall((:SoapySDRDevice_hasFrequencyCorrection, soapysdr), Bool, (Ptr{SoapySDRDevice}, Cint, Csize_t), device, direction, channel)
+    @soapy_checked ccall((:SoapySDRDevice_hasFrequencyCorrection, soapysdr), Bool, (Ptr{SoapySDRDevice}, Cint, Csize_t), device, direction, channel)
 end
 
 """
@@ -1005,7 +1005,7 @@ Fine tune the frontend frequency correction.
 \\return an error code or 0 for success
 """
 function SoapySDRDevice_setFrequencyCorrection(device, direction, channel, value)
-    ccall((:SoapySDRDevice_setFrequencyCorrection, soapysdr), Cint, (Ptr{SoapySDRDevice}, Cint, Csize_t, Cdouble), device, direction, channel, value)
+    @soapy_checked ccall((:SoapySDRDevice_setFrequencyCorrection, soapysdr), Cint, (Ptr{SoapySDRDevice}, Cint, Csize_t, Cdouble), device, direction, channel, value)
 end
 
 """
@@ -1018,7 +1018,7 @@ Get the frontend frequency correction value.
 \\return the correction value in PPM
 """
 function SoapySDRDevice_getFrequencyCorrection(device, direction, channel)
-    ccall((:SoapySDRDevice_getFrequencyCorrection, soapysdr), Cdouble, (Ptr{SoapySDRDevice}, Cint, Csize_t), device, direction, channel)
+    @soapy_checked ccall((:SoapySDRDevice_getFrequencyCorrection, soapysdr), Cdouble, (Ptr{SoapySDRDevice}, Cint, Csize_t), device, direction, channel)
 end
 
 """
@@ -1033,7 +1033,7 @@ Elements should be in order RF to baseband.
 \\return a list of gain string names
 """
 function SoapySDRDevice_listGains(device, direction, channel, length)
-    ccall((:SoapySDRDevice_listGains, soapysdr), Ptr{Ptr{Cchar}}, (Ptr{SoapySDRDevice}, Cint, Csize_t, Ptr{Csize_t}), device, direction, channel, length)
+    @soapy_checked ccall((:SoapySDRDevice_listGains, soapysdr), Ptr{Ptr{Cchar}}, (Ptr{SoapySDRDevice}, Cint, Csize_t, Ptr{Csize_t}), device, direction, channel, length)
 end
 
 """
@@ -1046,7 +1046,7 @@ Does the device support automatic gain control?
 \\return true for automatic gain control
 """
 function SoapySDRDevice_hasGainMode(device, direction, channel)
-    ccall((:SoapySDRDevice_hasGainMode, soapysdr), Bool, (Ptr{SoapySDRDevice}, Cint, Csize_t), device, direction, channel)
+    @soapy_checked ccall((:SoapySDRDevice_hasGainMode, soapysdr), Bool, (Ptr{SoapySDRDevice}, Cint, Csize_t), device, direction, channel)
 end
 
 """
@@ -1060,7 +1060,7 @@ Set the automatic gain mode on the chain.
 \\return an error code or 0 for success
 """
 function SoapySDRDevice_setGainMode(device, direction, channel, automatic)
-    ccall((:SoapySDRDevice_setGainMode, soapysdr), Cint, (Ptr{SoapySDRDevice}, Cint, Csize_t, Bool), device, direction, channel, automatic)
+    @soapy_checked ccall((:SoapySDRDevice_setGainMode, soapysdr), Cint, (Ptr{SoapySDRDevice}, Cint, Csize_t, Bool), device, direction, channel, automatic)
 end
 
 """
@@ -1073,7 +1073,7 @@ Get the automatic gain mode on the chain.
 \\return true for automatic gain setting
 """
 function SoapySDRDevice_getGainMode(device, direction, channel)
-    ccall((:SoapySDRDevice_getGainMode, soapysdr), Bool, (Ptr{SoapySDRDevice}, Cint, Csize_t), device, direction, channel)
+    @soapy_checked ccall((:SoapySDRDevice_getGainMode, soapysdr), Bool, (Ptr{SoapySDRDevice}, Cint, Csize_t), device, direction, channel)
 end
 
 """
@@ -1088,7 +1088,7 @@ The gain will be distributed automatically across available element.
 \\return an error code or 0 for success
 """
 function SoapySDRDevice_setGain(device, direction, channel, value)
-    ccall((:SoapySDRDevice_setGain, soapysdr), Cint, (Ptr{SoapySDRDevice}, Cint, Csize_t, Cdouble), device, direction, channel, value)
+    @soapy_checked ccall((:SoapySDRDevice_setGain, soapysdr), Cint, (Ptr{SoapySDRDevice}, Cint, Csize_t, Cdouble), device, direction, channel, value)
 end
 
 """
@@ -1103,7 +1103,7 @@ Set the value of a amplification element in a chain.
 \\return an error code or 0 for success
 """
 function SoapySDRDevice_setGainElement(device, direction, channel, name, value)
-    ccall((:SoapySDRDevice_setGainElement, soapysdr), Cint, (Ptr{SoapySDRDevice}, Cint, Csize_t, Ptr{Cchar}, Cdouble), device, direction, channel, name, value)
+    @soapy_checked ccall((:SoapySDRDevice_setGainElement, soapysdr), Cint, (Ptr{SoapySDRDevice}, Cint, Csize_t, Ptr{Cchar}, Cdouble), device, direction, channel, name, value)
 end
 
 """
@@ -1116,7 +1116,7 @@ Get the overall value of the gain elements in a chain.
 \\return the value of the gain in dB
 """
 function SoapySDRDevice_getGain(device, direction, channel)
-    ccall((:SoapySDRDevice_getGain, soapysdr), Cdouble, (Ptr{SoapySDRDevice}, Cint, Csize_t), device, direction, channel)
+    @soapy_checked ccall((:SoapySDRDevice_getGain, soapysdr), Cdouble, (Ptr{SoapySDRDevice}, Cint, Csize_t), device, direction, channel)
 end
 
 """
@@ -1130,7 +1130,7 @@ Get the value of an individual amplification element in a chain.
 \\return the value of the gain in dB
 """
 function SoapySDRDevice_getGainElement(device, direction, channel, name)
-    ccall((:SoapySDRDevice_getGainElement, soapysdr), Cdouble, (Ptr{SoapySDRDevice}, Cint, Csize_t, Ptr{Cchar}), device, direction, channel, name)
+    @soapy_checked ccall((:SoapySDRDevice_getGainElement, soapysdr), Cdouble, (Ptr{SoapySDRDevice}, Cint, Csize_t, Ptr{Cchar}), device, direction, channel, name)
 end
 
 """
@@ -1143,7 +1143,7 @@ Get the overall range of possible gain values.
 \\return the range of possible gain values for this channel in dB
 """
 function SoapySDRDevice_getGainRange(device, direction, channel)
-    ccall((:SoapySDRDevice_getGainRange, soapysdr), SoapySDRRange, (Ptr{SoapySDRDevice}, Cint, Csize_t), device, direction, channel)
+    @soapy_checked ccall((:SoapySDRDevice_getGainRange, soapysdr), SoapySDRRange, (Ptr{SoapySDRDevice}, Cint, Csize_t), device, direction, channel)
 end
 
 """
@@ -1157,7 +1157,7 @@ Get the range of possible gain values for a specific element.
 \\return the range of possible gain values for the specified amplification element in dB
 """
 function SoapySDRDevice_getGainElementRange(device, direction, channel, name)
-    ccall((:SoapySDRDevice_getGainElementRange, soapysdr), SoapySDRRange, (Ptr{SoapySDRDevice}, Cint, Csize_t, Ptr{Cchar}), device, direction, channel, name)
+    @soapy_checked ccall((:SoapySDRDevice_getGainElementRange, soapysdr), SoapySDRRange, (Ptr{SoapySDRDevice}, Cint, Csize_t, Ptr{Cchar}), device, direction, channel, name)
 end
 
 """
@@ -1192,7 +1192,7 @@ The args can be used to augment the tuning algorithm.
 \\return an error code or 0 for success
 """
 function SoapySDRDevice_setFrequency(device, direction, channel, frequency, args)
-    ccall((:SoapySDRDevice_setFrequency, soapysdr), Cint, (Ptr{SoapySDRDevice}, Cint, Csize_t, Cdouble, Ptr{SoapySDRKwargs}), device, direction, channel, frequency, args)
+    @soapy_checked ccall((:SoapySDRDevice_setFrequency, soapysdr), Cint, (Ptr{SoapySDRDevice}, Cint, Csize_t, Cdouble, Ptr{SoapySDRKwargs}), device, direction, channel, frequency, args)
 end
 
 """
@@ -1216,7 +1216,7 @@ Recommended names used to represent tunable components:
 \\return an error code or 0 for success
 """
 function SoapySDRDevice_setFrequencyComponent(device, direction, channel, name, frequency, args)
-    ccall((:SoapySDRDevice_setFrequencyComponent, soapysdr), Cint, (Ptr{SoapySDRDevice}, Cint, Csize_t, Ptr{Cchar}, Cdouble, Ptr{SoapySDRKwargs}), device, direction, channel, name, frequency, args)
+    @soapy_checked ccall((:SoapySDRDevice_setFrequencyComponent, soapysdr), Cint, (Ptr{SoapySDRDevice}, Cint, Csize_t, Ptr{Cchar}, Cdouble, Ptr{SoapySDRKwargs}), device, direction, channel, name, frequency, args)
 end
 
 """
@@ -1231,7 +1231,7 @@ Get the overall center frequency of the chain.
 \\return the center frequency in Hz
 """
 function SoapySDRDevice_getFrequency(device, direction, channel)
-    ccall((:SoapySDRDevice_getFrequency, soapysdr), Cdouble, (Ptr{SoapySDRDevice}, Cint, Csize_t), device, direction, channel)
+    @soapy_checked ccall((:SoapySDRDevice_getFrequency, soapysdr), Cdouble, (Ptr{SoapySDRDevice}, Cint, Csize_t), device, direction, channel)
 end
 
 """
@@ -1245,7 +1245,7 @@ Get the frequency of a tunable element in the chain.
 \\return the tunable element's frequency in Hz
 """
 function SoapySDRDevice_getFrequencyComponent(device, direction, channel, name)
-    ccall((:SoapySDRDevice_getFrequencyComponent, soapysdr), Cdouble, (Ptr{SoapySDRDevice}, Cint, Csize_t, Ptr{Cchar}), device, direction, channel, name)
+    @soapy_checked ccall((:SoapySDRDevice_getFrequencyComponent, soapysdr), Cdouble, (Ptr{SoapySDRDevice}, Cint, Csize_t, Ptr{Cchar}), device, direction, channel, name)
 end
 
 """
@@ -1260,7 +1260,7 @@ Elements should be in order RF to baseband.
 \\return a list of tunable elements by name
 """
 function SoapySDRDevice_listFrequencies(device, direction, channel, length)
-    ccall((:SoapySDRDevice_listFrequencies, soapysdr), Ptr{Ptr{Cchar}}, (Ptr{SoapySDRDevice}, Cint, Csize_t, Ptr{Csize_t}), device, direction, channel, length)
+    @soapy_checked ccall((:SoapySDRDevice_listFrequencies, soapysdr), Ptr{Ptr{Cchar}}, (Ptr{SoapySDRDevice}, Cint, Csize_t, Ptr{Csize_t}), device, direction, channel, length)
 end
 
 """
@@ -1274,7 +1274,7 @@ Get the range of overall frequency values.
 \\return a list of frequency ranges in Hz
 """
 function SoapySDRDevice_getFrequencyRange(device, direction, channel, length)
-    ccall((:SoapySDRDevice_getFrequencyRange, soapysdr), Ptr{SoapySDRRange}, (Ptr{SoapySDRDevice}, Cint, Csize_t, Ptr{Csize_t}), device, direction, channel, length)
+    @soapy_checked ccall((:SoapySDRDevice_getFrequencyRange, soapysdr), Ptr{SoapySDRRange}, (Ptr{SoapySDRDevice}, Cint, Csize_t, Ptr{Csize_t}), device, direction, channel, length)
 end
 
 """
@@ -1289,7 +1289,7 @@ Get the range of tunable values for the specified element.
 \\return a list of frequency ranges in Hz
 """
 function SoapySDRDevice_getFrequencyRangeComponent(device, direction, channel, name, length)
-    ccall((:SoapySDRDevice_getFrequencyRangeComponent, soapysdr), Ptr{SoapySDRRange}, (Ptr{SoapySDRDevice}, Cint, Csize_t, Ptr{Cchar}, Ptr{Csize_t}), device, direction, channel, name, length)
+    @soapy_checked ccall((:SoapySDRDevice_getFrequencyRangeComponent, soapysdr), Ptr{SoapySDRRange}, (Ptr{SoapySDRDevice}, Cint, Csize_t, Ptr{Cchar}, Ptr{Csize_t}), device, direction, channel, name, length)
 end
 
 """
@@ -1303,7 +1303,7 @@ Query the argument info description for tune args.
 \\return a list of argument info structures
 """
 function SoapySDRDevice_getFrequencyArgsInfo(device, direction, channel, length)
-    ccall((:SoapySDRDevice_getFrequencyArgsInfo, soapysdr), Ptr{SoapySDRArgInfo}, (Ptr{SoapySDRDevice}, Cint, Csize_t, Ptr{Csize_t}), device, direction, channel, length)
+    @soapy_checked ccall((:SoapySDRDevice_getFrequencyArgsInfo, soapysdr), Ptr{SoapySDRArgInfo}, (Ptr{SoapySDRDevice}, Cint, Csize_t, Ptr{Csize_t}), device, direction, channel, length)
 end
 
 """
@@ -1317,7 +1317,7 @@ Set the baseband sample rate of the chain.
 \\return an error code or 0 for success
 """
 function SoapySDRDevice_setSampleRate(device, direction, channel, rate)
-    ccall((:SoapySDRDevice_setSampleRate, soapysdr), Cint, (Ptr{SoapySDRDevice}, Cint, Csize_t, Cdouble), device, direction, channel, rate)
+    @soapy_checked ccall((:SoapySDRDevice_setSampleRate, soapysdr), Cint, (Ptr{SoapySDRDevice}, Cint, Csize_t, Cdouble), device, direction, channel, rate)
 end
 
 """
@@ -1330,7 +1330,7 @@ Get the baseband sample rate of the chain.
 \\return the sample rate in samples per second
 """
 function SoapySDRDevice_getSampleRate(device, direction, channel)
-    ccall((:SoapySDRDevice_getSampleRate, soapysdr), Cdouble, (Ptr{SoapySDRDevice}, Cint, Csize_t), device, direction, channel)
+    @soapy_checked ccall((:SoapySDRDevice_getSampleRate, soapysdr), Cdouble, (Ptr{SoapySDRDevice}, Cint, Csize_t), device, direction, channel)
 end
 
 """
@@ -1345,7 +1345,7 @@ Get the range of possible baseband sample rates.
 \\return a list of possible rates in samples per second
 """
 function SoapySDRDevice_listSampleRates(device, direction, channel, length)
-    ccall((:SoapySDRDevice_listSampleRates, soapysdr), Ptr{Cdouble}, (Ptr{SoapySDRDevice}, Cint, Csize_t, Ptr{Csize_t}), device, direction, channel, length)
+    @soapy_checked ccall((:SoapySDRDevice_listSampleRates, soapysdr), Ptr{Cdouble}, (Ptr{SoapySDRDevice}, Cint, Csize_t, Ptr{Csize_t}), device, direction, channel, length)
 end
 
 """
@@ -1359,7 +1359,7 @@ Get the range of possible baseband sample rates.
 \\return a list of sample rate ranges in samples per second
 """
 function SoapySDRDevice_getSampleRateRange(device, direction, channel, length)
-    ccall((:SoapySDRDevice_getSampleRateRange, soapysdr), Ptr{SoapySDRRange}, (Ptr{SoapySDRDevice}, Cint, Csize_t, Ptr{Csize_t}), device, direction, channel, length)
+    @soapy_checked ccall((:SoapySDRDevice_getSampleRateRange, soapysdr), Ptr{SoapySDRRange}, (Ptr{SoapySDRDevice}, Cint, Csize_t, Ptr{Csize_t}), device, direction, channel, length)
 end
 
 """
@@ -1373,7 +1373,7 @@ Set the baseband filter width of the chain.
 \\return an error code or 0 for success
 """
 function SoapySDRDevice_setBandwidth(device, direction, channel, bw)
-    ccall((:SoapySDRDevice_setBandwidth, soapysdr), Cint, (Ptr{SoapySDRDevice}, Cint, Csize_t, Cdouble), device, direction, channel, bw)
+    @soapy_checked ccall((:SoapySDRDevice_setBandwidth, soapysdr), Cint, (Ptr{SoapySDRDevice}, Cint, Csize_t, Cdouble), device, direction, channel, bw)
 end
 
 """
@@ -1386,7 +1386,7 @@ Get the baseband filter width of the chain.
 \\return the baseband filter width in Hz
 """
 function SoapySDRDevice_getBandwidth(device, direction, channel)
-    ccall((:SoapySDRDevice_getBandwidth, soapysdr), Cdouble, (Ptr{SoapySDRDevice}, Cint, Csize_t), device, direction, channel)
+    @soapy_checked ccall((:SoapySDRDevice_getBandwidth, soapysdr), Cdouble, (Ptr{SoapySDRDevice}, Cint, Csize_t), device, direction, channel)
 end
 
 """
@@ -1401,7 +1401,7 @@ Get the range of possible baseband filter widths.
 \\return a list of possible bandwidths in Hz
 """
 function SoapySDRDevice_listBandwidths(device, direction, channel, length)
-    ccall((:SoapySDRDevice_listBandwidths, soapysdr), Ptr{Cdouble}, (Ptr{SoapySDRDevice}, Cint, Csize_t, Ptr{Csize_t}), device, direction, channel, length)
+    @soapy_checked ccall((:SoapySDRDevice_listBandwidths, soapysdr), Ptr{Cdouble}, (Ptr{SoapySDRDevice}, Cint, Csize_t, Ptr{Csize_t}), device, direction, channel, length)
 end
 
 """
@@ -1415,7 +1415,7 @@ Get the range of possible baseband filter widths.
 \\return a list of bandwidth ranges in Hz
 """
 function SoapySDRDevice_getBandwidthRange(device, direction, channel, length)
-    ccall((:SoapySDRDevice_getBandwidthRange, soapysdr), Ptr{SoapySDRRange}, (Ptr{SoapySDRDevice}, Cint, Csize_t, Ptr{Csize_t}), device, direction, channel, length)
+    @soapy_checked ccall((:SoapySDRDevice_getBandwidthRange, soapysdr), Ptr{SoapySDRRange}, (Ptr{SoapySDRDevice}, Cint, Csize_t, Ptr{Csize_t}), device, direction, channel, length)
 end
 
 """
@@ -1427,7 +1427,7 @@ Set the master clock rate of the device.
 \\return an error code or 0 for success
 """
 function SoapySDRDevice_setMasterClockRate(device, rate)
-    ccall((:SoapySDRDevice_setMasterClockRate, soapysdr), Cint, (Ptr{SoapySDRDevice}, Cdouble), device, rate)
+    @soapy_checked ccall((:SoapySDRDevice_setMasterClockRate, soapysdr), Cint, (Ptr{SoapySDRDevice}, Cdouble), device, rate)
 end
 
 """
@@ -1438,7 +1438,7 @@ Get the master clock rate of the device.
 \\return the clock rate in Hz
 """
 function SoapySDRDevice_getMasterClockRate(device)
-    ccall((:SoapySDRDevice_getMasterClockRate, soapysdr), Cdouble, (Ptr{SoapySDRDevice},), device)
+    @soapy_checked ccall((:SoapySDRDevice_getMasterClockRate, soapysdr), Cdouble, (Ptr{SoapySDRDevice},), device)
 end
 
 """
@@ -1450,7 +1450,7 @@ Get the range of available master clock rates.
 \\return a list of clock rate ranges in Hz
 """
 function SoapySDRDevice_getMasterClockRates(device, length)
-    ccall((:SoapySDRDevice_getMasterClockRates, soapysdr), Ptr{SoapySDRRange}, (Ptr{SoapySDRDevice}, Ptr{Csize_t}), device, length)
+    @soapy_checked ccall((:SoapySDRDevice_getMasterClockRates, soapysdr), Ptr{SoapySDRRange}, (Ptr{SoapySDRDevice}, Ptr{Csize_t}), device, length)
 end
 
 """
@@ -1462,7 +1462,7 @@ Set the reference clock rate of the device.
 \\return an error code or 0 for success
 """
 function SoapySDRDevice_setReferenceClockRate(device, rate)
-    ccall((:SoapySDRDevice_setReferenceClockRate, soapysdr), Cint, (Ptr{SoapySDRDevice}, Cdouble), device, rate)
+    @soapy_checked ccall((:SoapySDRDevice_setReferenceClockRate, soapysdr), Cint, (Ptr{SoapySDRDevice}, Cdouble), device, rate)
 end
 
 """
@@ -1473,7 +1473,7 @@ Get the reference clock rate of the device.
 \\return the clock rate in Hz
 """
 function SoapySDRDevice_getReferenceClockRate(device)
-    ccall((:SoapySDRDevice_getReferenceClockRate, soapysdr), Cdouble, (Ptr{SoapySDRDevice},), device)
+    @soapy_checked ccall((:SoapySDRDevice_getReferenceClockRate, soapysdr), Cdouble, (Ptr{SoapySDRDevice},), device)
 end
 
 """
@@ -1497,7 +1497,7 @@ Get the list of available clock sources.
 \\return a list of clock source names
 """
 function SoapySDRDevice_listClockSources(device, length)
-    ccall((:SoapySDRDevice_listClockSources, soapysdr), Ptr{Ptr{Cchar}}, (Ptr{SoapySDRDevice}, Ptr{Csize_t}), device, length)
+    @soapy_checked ccall((:SoapySDRDevice_listClockSources, soapysdr), Ptr{Ptr{Cchar}}, (Ptr{SoapySDRDevice}, Ptr{Csize_t}), device, length)
 end
 
 """
@@ -1509,7 +1509,7 @@ Set the clock source on the device
 \\return an error code or 0 for success
 """
 function SoapySDRDevice_setClockSource(device, source)
-    ccall((:SoapySDRDevice_setClockSource, soapysdr), Cint, (Ptr{SoapySDRDevice}, Ptr{Cchar}), device, source)
+    @soapy_checked ccall((:SoapySDRDevice_setClockSource, soapysdr), Cint, (Ptr{SoapySDRDevice}, Ptr{Cchar}), device, source)
 end
 
 """
@@ -1520,7 +1520,7 @@ Get the clock source of the device
 \\return the name of a clock source
 """
 function SoapySDRDevice_getClockSource(device)
-    ccall((:SoapySDRDevice_getClockSource, soapysdr), Ptr{Cchar}, (Ptr{SoapySDRDevice},), device)
+    @soapy_checked ccall((:SoapySDRDevice_getClockSource, soapysdr), Ptr{Cchar}, (Ptr{SoapySDRDevice},), device)
 end
 
 """
@@ -1532,7 +1532,7 @@ Get the list of available time sources.
 \\return a list of time source names
 """
 function SoapySDRDevice_listTimeSources(device, length)
-    ccall((:SoapySDRDevice_listTimeSources, soapysdr), Ptr{Ptr{Cchar}}, (Ptr{SoapySDRDevice}, Ptr{Csize_t}), device, length)
+    @soapy_checked ccall((:SoapySDRDevice_listTimeSources, soapysdr), Ptr{Ptr{Cchar}}, (Ptr{SoapySDRDevice}, Ptr{Csize_t}), device, length)
 end
 
 """
@@ -1544,7 +1544,7 @@ Set the time source on the device
 \\return an error code or 0 for success
 """
 function SoapySDRDevice_setTimeSource(device, source)
-    ccall((:SoapySDRDevice_setTimeSource, soapysdr), Cint, (Ptr{SoapySDRDevice}, Ptr{Cchar}), device, source)
+    @soapy_checked ccall((:SoapySDRDevice_setTimeSource, soapysdr), Cint, (Ptr{SoapySDRDevice}, Ptr{Cchar}), device, source)
 end
 
 """
@@ -1555,7 +1555,7 @@ Get the time source of the device
 \\return the name of a time source
 """
 function SoapySDRDevice_getTimeSource(device)
-    ccall((:SoapySDRDevice_getTimeSource, soapysdr), Ptr{Cchar}, (Ptr{SoapySDRDevice},), device)
+    @soapy_checked ccall((:SoapySDRDevice_getTimeSource, soapysdr), Ptr{Cchar}, (Ptr{SoapySDRDevice},), device)
 end
 
 """
@@ -1567,7 +1567,7 @@ Does this device have a hardware clock?
 \\return true if the hardware clock exists
 """
 function SoapySDRDevice_hasHardwareTime(device, what)
-    ccall((:SoapySDRDevice_hasHardwareTime, soapysdr), Bool, (Ptr{SoapySDRDevice}, Ptr{Cchar}), device, what)
+    @soapy_checked ccall((:SoapySDRDevice_hasHardwareTime, soapysdr), Bool, (Ptr{SoapySDRDevice}, Ptr{Cchar}), device, what)
 end
 
 """
@@ -1580,7 +1580,7 @@ The what argument can refer to a specific time counter.
 \\return the time in nanoseconds
 """
 function SoapySDRDevice_getHardwareTime(device, what)
-    ccall((:SoapySDRDevice_getHardwareTime, soapysdr), Clonglong, (Ptr{SoapySDRDevice}, Ptr{Cchar}), device, what)
+    @soapy_checked ccall((:SoapySDRDevice_getHardwareTime, soapysdr), Clonglong, (Ptr{SoapySDRDevice}, Ptr{Cchar}), device, what)
 end
 
 """
@@ -1594,7 +1594,7 @@ The what argument can refer to a specific time counter.
 \\return 0 for success or error code on failure
 """
 function SoapySDRDevice_setHardwareTime(device, timeNs, what)
-    ccall((:SoapySDRDevice_setHardwareTime, soapysdr), Cint, (Ptr{SoapySDRDevice}, Clonglong, Ptr{Cchar}), device, timeNs, what)
+    @soapy_checked ccall((:SoapySDRDevice_setHardwareTime, soapysdr), Cint, (Ptr{SoapySDRDevice}, Clonglong, Ptr{Cchar}), device, timeNs, what)
 end
 
 """
@@ -1610,7 +1610,7 @@ Implementations may use a time of 0 to clear.
 \\return 0 for success or error code on failure
 """
 function SoapySDRDevice_setCommandTime(device, timeNs, what)
-    ccall((:SoapySDRDevice_setCommandTime, soapysdr), Cint, (Ptr{SoapySDRDevice}, Clonglong, Ptr{Cchar}), device, timeNs, what)
+    @soapy_checked ccall((:SoapySDRDevice_setCommandTime, soapysdr), Cint, (Ptr{SoapySDRDevice}, Clonglong, Ptr{Cchar}), device, timeNs, what)
 end
 
 """
@@ -1623,7 +1623,7 @@ A sensor can represent a reference lock, RSSI, temperature.
 \\return a list of available sensor string names
 """
 function SoapySDRDevice_listSensors(device, length)
-    ccall((:SoapySDRDevice_listSensors, soapysdr), Ptr{Ptr{Cchar}}, (Ptr{SoapySDRDevice}, Ptr{Csize_t}), device, length)
+    @soapy_checked ccall((:SoapySDRDevice_listSensors, soapysdr), Ptr{Ptr{Cchar}}, (Ptr{SoapySDRDevice}, Ptr{Csize_t}), device, length)
 end
 
 """
@@ -1636,7 +1636,7 @@ Example: displayable name, type, range.
 \\return meta-information about a sensor
 """
 function SoapySDRDevice_getSensorInfo(device, key)
-    ccall((:SoapySDRDevice_getSensorInfo, soapysdr), SoapySDRArgInfo, (Ptr{SoapySDRDevice}, Ptr{Cchar}), device, key)
+    @soapy_checked ccall((:SoapySDRDevice_getSensorInfo, soapysdr), SoapySDRArgInfo, (Ptr{SoapySDRDevice}, Ptr{Cchar}), device, key)
 end
 
 """
@@ -1650,7 +1650,7 @@ a boolean ("true"/"false"), an integer, or float.
 \\return the current value of the sensor
 """
 function SoapySDRDevice_readSensor(device, key)
-    ccall((:SoapySDRDevice_readSensor, soapysdr), Ptr{Cchar}, (Ptr{SoapySDRDevice}, Ptr{Cchar}), device, key)
+    @soapy_checked ccall((:SoapySDRDevice_readSensor, soapysdr), Ptr{Cchar}, (Ptr{SoapySDRDevice}, Ptr{Cchar}), device, key)
 end
 
 """
@@ -1665,7 +1665,7 @@ A sensor can represent a reference lock, RSSI, temperature.
 \\return a list of available sensor string names
 """
 function SoapySDRDevice_listChannelSensors(device, direction, channel, length)
-    ccall((:SoapySDRDevice_listChannelSensors, soapysdr), Ptr{Ptr{Cchar}}, (Ptr{SoapySDRDevice}, Cint, Csize_t, Ptr{Csize_t}), device, direction, channel, length)
+    @soapy_checked ccall((:SoapySDRDevice_listChannelSensors, soapysdr), Ptr{Ptr{Cchar}}, (Ptr{SoapySDRDevice}, Cint, Csize_t, Ptr{Csize_t}), device, direction, channel, length)
 end
 
 """
@@ -1680,7 +1680,7 @@ Example: displayable name, type, range.
 \\return meta-information about a sensor
 """
 function SoapySDRDevice_getChannelSensorInfo(device, direction, channel, key)
-    ccall((:SoapySDRDevice_getChannelSensorInfo, soapysdr), SoapySDRArgInfo, (Ptr{SoapySDRDevice}, Cint, Csize_t, Ptr{Cchar}), device, direction, channel, key)
+    @soapy_checked ccall((:SoapySDRDevice_getChannelSensorInfo, soapysdr), SoapySDRArgInfo, (Ptr{SoapySDRDevice}, Cint, Csize_t, Ptr{Cchar}), device, direction, channel, key)
 end
 
 """
@@ -1696,7 +1696,7 @@ a boolean ("true"/"false"), an integer, or float.
 \\return the current value of the sensor
 """
 function SoapySDRDevice_readChannelSensor(device, direction, channel, key)
-    ccall((:SoapySDRDevice_readChannelSensor, soapysdr), Ptr{Cchar}, (Ptr{SoapySDRDevice}, Cint, Csize_t, Ptr{Cchar}), device, direction, channel, key)
+    @soapy_checked ccall((:SoapySDRDevice_readChannelSensor, soapysdr), Ptr{Cchar}, (Ptr{SoapySDRDevice}, Cint, Csize_t, Ptr{Cchar}), device, direction, channel, key)
 end
 
 """
@@ -1708,7 +1708,7 @@ Get a list of available register interfaces by name.
 \\return a list of available register interfaces
 """
 function SoapySDRDevice_listRegisterInterfaces(device, length)
-    ccall((:SoapySDRDevice_listRegisterInterfaces, soapysdr), Ptr{Ptr{Cchar}}, (Ptr{SoapySDRDevice}, Ptr{Csize_t}), device, length)
+    @soapy_checked ccall((:SoapySDRDevice_listRegisterInterfaces, soapysdr), Ptr{Ptr{Cchar}}, (Ptr{SoapySDRDevice}, Ptr{Csize_t}), device, length)
 end
 
 """
@@ -1724,7 +1724,7 @@ the interpretation is up the implementation to decide.
 \\return 0 for success or error code on failure
 """
 function SoapySDRDevice_writeRegister(device, name, addr, value)
-    ccall((:SoapySDRDevice_writeRegister, soapysdr), Cint, (Ptr{SoapySDRDevice}, Ptr{Cchar}, Cuint, Cuint), device, name, addr, value)
+    @soapy_checked ccall((:SoapySDRDevice_writeRegister, soapysdr), Cint, (Ptr{SoapySDRDevice}, Ptr{Cchar}, Cuint, Cuint), device, name, addr, value)
 end
 
 """
@@ -1737,7 +1737,7 @@ Read a register on the device given the interface name.
 \\return the register value
 """
 function SoapySDRDevice_readRegister(device, name, addr)
-    ccall((:SoapySDRDevice_readRegister, soapysdr), Cuint, (Ptr{SoapySDRDevice}, Ptr{Cchar}, Cuint), device, name, addr)
+    @soapy_checked ccall((:SoapySDRDevice_readRegister, soapysdr), Cuint, (Ptr{SoapySDRDevice}, Ptr{Cchar}, Cuint), device, name, addr)
 end
 
 """
@@ -1754,7 +1754,7 @@ the interpretation is up the implementation to decide.
 \\return 0 for success or error code on failure
 """
 function SoapySDRDevice_writeRegisters(device, name, addr, value, length)
-    ccall((:SoapySDRDevice_writeRegisters, soapysdr), Cint, (Ptr{SoapySDRDevice}, Ptr{Cchar}, Cuint, Ptr{Cuint}, Csize_t), device, name, addr, value, length)
+    @soapy_checked ccall((:SoapySDRDevice_writeRegisters, soapysdr), Cint, (Ptr{SoapySDRDevice}, Ptr{Cchar}, Cuint, Ptr{Cuint}, Csize_t), device, name, addr, value, length)
 end
 
 """
@@ -1770,7 +1770,7 @@ length will be set to the number of actual words read.
 \\return the memory block content
 """
 function SoapySDRDevice_readRegisters(device, name, addr, length)
-    ccall((:SoapySDRDevice_readRegisters, soapysdr), Ptr{Cuint}, (Ptr{SoapySDRDevice}, Ptr{Cchar}, Cuint, Ptr{Csize_t}), device, name, addr, length)
+    @soapy_checked ccall((:SoapySDRDevice_readRegisters, soapysdr), Ptr{Cuint}, (Ptr{SoapySDRDevice}, Ptr{Cchar}, Cuint, Ptr{Csize_t}), device, name, addr, length)
 end
 
 """
@@ -1782,7 +1782,7 @@ Describe the allowed keys and values used for settings.
 \\return a list of argument info structures
 """
 function SoapySDRDevice_getSettingInfo(device, length)
-    ccall((:SoapySDRDevice_getSettingInfo, soapysdr), Ptr{SoapySDRArgInfo}, (Ptr{SoapySDRDevice}, Ptr{Csize_t}), device, length)
+    @soapy_checked ccall((:SoapySDRDevice_getSettingInfo, soapysdr), Ptr{SoapySDRArgInfo}, (Ptr{SoapySDRDevice}, Ptr{Csize_t}), device, length)
 end
 
 """
@@ -1796,7 +1796,7 @@ The interpretation is up the implementation.
 \\return 0 for success or error code on failure
 """
 function SoapySDRDevice_writeSetting(device, key, value)
-    ccall((:SoapySDRDevice_writeSetting, soapysdr), Cint, (Ptr{SoapySDRDevice}, Ptr{Cchar}, Ptr{Cchar}), device, key, value)
+    @soapy_checked ccall((:SoapySDRDevice_writeSetting, soapysdr), Cint, (Ptr{SoapySDRDevice}, Ptr{Cchar}, Ptr{Cchar}), device, key, value)
 end
 
 """
@@ -1808,7 +1808,7 @@ Read an arbitrary setting on the device.
 \\return the setting value
 """
 function SoapySDRDevice_readSetting(device, key)
-    ccall((:SoapySDRDevice_readSetting, soapysdr), Ptr{Cchar}, (Ptr{SoapySDRDevice}, Ptr{Cchar}), device, key)
+    @soapy_checked ccall((:SoapySDRDevice_readSetting, soapysdr), Ptr{Cchar}, (Ptr{SoapySDRDevice}, Ptr{Cchar}), device, key)
 end
 
 """
@@ -1822,7 +1822,7 @@ Describe the allowed keys and values used for channel settings.
 \\return a list of argument info structures
 """
 function SoapySDRDevice_getChannelSettingInfo(device, direction, channel, length)
-    ccall((:SoapySDRDevice_getChannelSettingInfo, soapysdr), Ptr{SoapySDRArgInfo}, (Ptr{SoapySDRDevice}, Cint, Csize_t, Ptr{Csize_t}), device, direction, channel, length)
+    @soapy_checked ccall((:SoapySDRDevice_getChannelSettingInfo, soapysdr), Ptr{SoapySDRArgInfo}, (Ptr{SoapySDRDevice}, Cint, Csize_t, Ptr{Csize_t}), device, direction, channel, length)
 end
 
 """
@@ -1838,7 +1838,7 @@ The interpretation is up the implementation.
 \\return 0 for success or error code on failure
 """
 function SoapySDRDevice_writeChannelSetting(device, direction, channel, key, value)
-    ccall((:SoapySDRDevice_writeChannelSetting, soapysdr), Cint, (Ptr{SoapySDRDevice}, Cint, Csize_t, Ptr{Cchar}, Ptr{Cchar}), device, direction, channel, key, value)
+    @soapy_checked ccall((:SoapySDRDevice_writeChannelSetting, soapysdr), Cint, (Ptr{SoapySDRDevice}, Cint, Csize_t, Ptr{Cchar}, Ptr{Cchar}), device, direction, channel, key, value)
 end
 
 """
@@ -1852,7 +1852,7 @@ Read an arbitrary channel setting on the device.
 \\return the setting value
 """
 function SoapySDRDevice_readChannelSetting(device, direction, channel, key)
-    ccall((:SoapySDRDevice_readChannelSetting, soapysdr), Ptr{Cchar}, (Ptr{SoapySDRDevice}, Cint, Csize_t, Ptr{Cchar}), device, direction, channel, key)
+    @soapy_checked ccall((:SoapySDRDevice_readChannelSetting, soapysdr), Ptr{Cchar}, (Ptr{SoapySDRDevice}, Cint, Csize_t, Ptr{Cchar}), device, direction, channel, key)
 end
 
 """
@@ -1863,7 +1863,7 @@ Get a list of available GPIO banks by name.
 \\param device a pointer to a device instance
 """
 function SoapySDRDevice_listGPIOBanks(device, length)
-    ccall((:SoapySDRDevice_listGPIOBanks, soapysdr), Ptr{Ptr{Cchar}}, (Ptr{SoapySDRDevice}, Ptr{Csize_t}), device, length)
+    @soapy_checked ccall((:SoapySDRDevice_listGPIOBanks, soapysdr), Ptr{Ptr{Cchar}}, (Ptr{SoapySDRDevice}, Ptr{Csize_t}), device, length)
 end
 
 """
@@ -1876,7 +1876,7 @@ Write the value of a GPIO bank.
 \\return 0 for success or error code on failure
 """
 function SoapySDRDevice_writeGPIO(device, bank, value)
-    ccall((:SoapySDRDevice_writeGPIO, soapysdr), Cint, (Ptr{SoapySDRDevice}, Ptr{Cchar}, Cuint), device, bank, value)
+    @soapy_checked ccall((:SoapySDRDevice_writeGPIO, soapysdr), Cint, (Ptr{SoapySDRDevice}, Ptr{Cchar}, Cuint), device, bank, value)
 end
 
 """
@@ -1890,7 +1890,7 @@ Write the value of a GPIO bank with modification mask.
 \\return 0 for success or error code on failure
 """
 function SoapySDRDevice_writeGPIOMasked(device, bank, value, mask)
-    ccall((:SoapySDRDevice_writeGPIOMasked, soapysdr), Cint, (Ptr{SoapySDRDevice}, Ptr{Cchar}, Cuint, Cuint), device, bank, value, mask)
+    @soapy_checked ccall((:SoapySDRDevice_writeGPIOMasked, soapysdr), Cint, (Ptr{SoapySDRDevice}, Ptr{Cchar}, Cuint, Cuint), device, bank, value, mask)
 end
 
 """
@@ -1902,7 +1902,7 @@ Readback the value of a GPIO bank.
 \\return an integer representing GPIO bits
 """
 function SoapySDRDevice_readGPIO(device, bank)
-    ccall((:SoapySDRDevice_readGPIO, soapysdr), Cuint, (Ptr{SoapySDRDevice}, Ptr{Cchar}), device, bank)
+    @soapy_checked ccall((:SoapySDRDevice_readGPIO, soapysdr), Cuint, (Ptr{SoapySDRDevice}, Ptr{Cchar}), device, bank)
 end
 
 """
@@ -1916,7 +1916,7 @@ Write the data direction of a GPIO bank.
 \\return 0 for success or error code on failure
 """
 function SoapySDRDevice_writeGPIODir(device, bank, dir)
-    ccall((:SoapySDRDevice_writeGPIODir, soapysdr), Cint, (Ptr{SoapySDRDevice}, Ptr{Cchar}, Cuint), device, bank, dir)
+    @soapy_checked ccall((:SoapySDRDevice_writeGPIODir, soapysdr), Cint, (Ptr{SoapySDRDevice}, Ptr{Cchar}, Cuint), device, bank, dir)
 end
 
 """
@@ -1931,7 +1931,7 @@ Write the data direction of a GPIO bank with modification mask.
 \\return 0 for success or error code on failure
 """
 function SoapySDRDevice_writeGPIODirMasked(device, bank, dir, mask)
-    ccall((:SoapySDRDevice_writeGPIODirMasked, soapysdr), Cint, (Ptr{SoapySDRDevice}, Ptr{Cchar}, Cuint, Cuint), device, bank, dir, mask)
+    @soapy_checked ccall((:SoapySDRDevice_writeGPIODirMasked, soapysdr), Cint, (Ptr{SoapySDRDevice}, Ptr{Cchar}, Cuint, Cuint), device, bank, dir, mask)
 end
 
 """
@@ -1944,7 +1944,7 @@ Read the data direction of a GPIO bank.
 \\return an integer representing data direction bits
 """
 function SoapySDRDevice_readGPIODir(device, bank)
-    ccall((:SoapySDRDevice_readGPIODir, soapysdr), Cuint, (Ptr{SoapySDRDevice}, Ptr{Cchar}), device, bank)
+    @soapy_checked ccall((:SoapySDRDevice_readGPIODir, soapysdr), Cuint, (Ptr{SoapySDRDevice}, Ptr{Cchar}), device, bank)
 end
 
 """
@@ -1960,7 +1960,7 @@ the address bits can encode which master.
 \\return 0 for success or error code on failure
 """
 function SoapySDRDevice_writeI2C(device, addr, data, numBytes)
-    ccall((:SoapySDRDevice_writeI2C, soapysdr), Cint, (Ptr{SoapySDRDevice}, Cint, Ptr{Cchar}, Csize_t), device, addr, data, numBytes)
+    @soapy_checked ccall((:SoapySDRDevice_writeI2C, soapysdr), Cint, (Ptr{SoapySDRDevice}, Cint, Ptr{Cchar}, Csize_t), device, addr, data, numBytes)
 end
 
 """
@@ -1977,7 +1977,7 @@ numBytes will be set to the number of actual bytes read.
 \\return an array of bytes read from the slave
 """
 function SoapySDRDevice_readI2C(device, addr, numBytes)
-    ccall((:SoapySDRDevice_readI2C, soapysdr), Ptr{Cchar}, (Ptr{SoapySDRDevice}, Cint, Ptr{Csize_t}), device, addr, numBytes)
+    @soapy_checked ccall((:SoapySDRDevice_readI2C, soapysdr), Ptr{Cchar}, (Ptr{SoapySDRDevice}, Cint, Ptr{Csize_t}), device, addr, numBytes)
 end
 
 """
@@ -1998,7 +1998,7 @@ the address bits can encode which master.
 \\return the readback data, numBits-1 is first in
 """
 function SoapySDRDevice_transactSPI(device, addr, data, numBits)
-    ccall((:SoapySDRDevice_transactSPI, soapysdr), Cuint, (Ptr{SoapySDRDevice}, Cint, Cuint, Csize_t), device, addr, data, numBits)
+    @soapy_checked ccall((:SoapySDRDevice_transactSPI, soapysdr), Cuint, (Ptr{SoapySDRDevice}, Cint, Cuint, Csize_t), device, addr, data, numBits)
 end
 
 """
@@ -2010,7 +2010,7 @@ Enumerate the available UART devices.
 \\return a list of names of available UARTs
 """
 function SoapySDRDevice_listUARTs(device, length)
-    ccall((:SoapySDRDevice_listUARTs, soapysdr), Ptr{Ptr{Cchar}}, (Ptr{SoapySDRDevice}, Ptr{Csize_t}), device, length)
+    @soapy_checked ccall((:SoapySDRDevice_listUARTs, soapysdr), Ptr{Ptr{Cchar}}, (Ptr{SoapySDRDevice}, Ptr{Csize_t}), device, length)
 end
 
 """
@@ -2025,7 +2025,7 @@ carriage return settings, flushing on newline.
 \\return 0 for success or error code on failure
 """
 function SoapySDRDevice_writeUART(device, which, data)
-    ccall((:SoapySDRDevice_writeUART, soapysdr), Cint, (Ptr{SoapySDRDevice}, Ptr{Cchar}, Ptr{Cchar}), device, which, data)
+    @soapy_checked ccall((:SoapySDRDevice_writeUART, soapysdr), Cint, (Ptr{SoapySDRDevice}, Ptr{Cchar}, Ptr{Cchar}), device, which, data)
 end
 
 """
@@ -2040,7 +2040,7 @@ carriage return settings, flushing on newline.
 \\return a null terminated array of bytes
 """
 function SoapySDRDevice_readUART(device, which, timeoutUs)
-    ccall((:SoapySDRDevice_readUART, soapysdr), Ptr{Cchar}, (Ptr{SoapySDRDevice}, Ptr{Cchar}, Clong), device, which, timeoutUs)
+    @soapy_checked ccall((:SoapySDRDevice_readUART, soapysdr), Ptr{Cchar}, (Ptr{SoapySDRDevice}, Ptr{Cchar}, Clong), device, which, timeoutUs)
 end
 
 """
@@ -2053,7 +2053,7 @@ or does not wish to provide access to the native handle.
 \\return a handle to the native device or null
 """
 function SoapySDRDevice_getNativeDeviceHandle(device)
-    ccall((:SoapySDRDevice_getNativeDeviceHandle, soapysdr), Ptr{Cvoid}, (Ptr{SoapySDRDevice},), device)
+    @soapy_checked ccall((:SoapySDRDevice_getNativeDeviceHandle, soapysdr), Ptr{Cvoid}, (Ptr{SoapySDRDevice},), device)
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -83,7 +83,7 @@ end
     io = IOBuffer(read=true, write=true)
 
     # Test failing to open a device due to an invalid specification
-    @test_throws ArgumentError Device(parse(KWArgs, "driver=foo"))
+    @test_throws SoapySDR.SoapySDRDeviceError Device(parse(KWArgs, "driver=foo"))
 
     # Device constructor, show, iterator
     @test length(Devices()) == 1


### PR DESCRIPTION
SoapySDR, being written in C++, uses C++ exceptions for most of its
error reporting.  However, when using the C API, these exceptions are
automatically caught, and recorded in a global `errno`-like system [0].
This means that without explicit error checking, we never notice that
we, for instance, fail to set the samplerate due to clock mismanagement.
This PR adds some error management helper functions, and litters our
function wrapper code with `@soapy_checked` to automatically throw
Julia exceptions when something goes awry.

[0] https://github.com/pothosware/SoapySDR/blob/4e71a35e5dec5b63fa95be572e3ad39adb260e15/lib/ErrorHelpers.hpp#L16-L19