### PR TITLE
make read/write operate on `Vector` rather than `NTuple`

### DIFF
--- a/examples/fmDemodHighLevel.jl
+++ b/examples/fmDemodHighLevel.jl
@@ -55,7 +55,7 @@ storeBuff = zeros(ComplexF32, timeSamp, buffsz)
 SoapySDR.activate!(rxStream)
 
 for i = 1:timeSamp
-    read!(rxStream, (buff,))
+    read!(rxStream, [buff])
     storeBuff[i, :] = buff
 end
 

--- a/examples/highlevel_loopback.jl
+++ b/examples/highlevel_loopback.jl
@@ -58,11 +58,11 @@ function loopback_test(s_tx, s_rx, num_buffers)
     # Read/write `num_buffers`, writing zeros out except for one buffer.
     for idx = 1:num_buffers
         if idx == ceil(num_buffers / 2)
-            Base.write(s_tx, (data_tx,))
+            Base.write(s_tx, [data_tx])
         else
-            Base.write(s_tx, (data_tx_zeros,))
+            Base.write(s_tx, [data_tx_zeros])
         end
-        Base.read!(s_rx, (data_rx_buffs[idx],))
+        Base.read!(s_rx, [data_rx_buffs[idx]])
     end
     SoapySDR.deactivate!.((s_tx, s_rx))
     return data_rx_buffs

--- a/examples/rapid_read.jl
+++ b/examples/rapid_read.jl
@@ -19,7 +19,7 @@ function rapid_read()
         current_buff = bufs[Int(flip)+1]
         prev_buff = bufs[Int(!flip)+1]
 
-        read!(rx_stream, (current_buff,))
+        read!(rx_stream, [current_buff])
 
         # sanity checks?
         #nequal = 0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -200,7 +200,7 @@ SoapySDR.register_log_handler()
         sd.activate!(tx_stream)
 
         # First, try to write an invalid buffer type, ensure that that errors
-        buffers = (zeros(ComplexF32, 10), zeros(ComplexF32, 11))
+        buffers = [zeros(ComplexF32, 10), zeros(ComplexF32, 11)]
         @test_throws ArgumentError write(tx_stream, buffers)
 
         # We (unfortunately) cannot do a write/read test, as that's not supported


### PR DESCRIPTION
This avoids a common source of type instability when constructing buffers given by the length of a channel.
This has the side effect of reducing allocations as well.