### PR TITLE
fix: make range formatting tests compatible with Julia nightly

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -87,8 +87,8 @@ SoapySDR.register_log_handler()
                     Int64,
                 }
 
-                @test sprint(sd.print_hz_range, intervalrangehz) == "00..0.001 kHz"
-                @test sprint(sd.print_hz_range, steprangehz) == "00 Hz:0.0001 kHz:0.001 kHz"
+                @test sprint(sd.print_hz_range, intervalrangehz) in ("0..0.001 kHz", "00..0.001 kHz")
+                @test sprint(sd.print_hz_range, steprangehz) in ("0 Hz:0.0001 kHz:0.001 kHz", "00 Hz:0.0001 kHz:0.001 kHz")
             end
         end
 


### PR DESCRIPTION
Julia nightly changed number formatting behavior - it now prints "0" instead of "00" for the leading zero in range outputs. Updated tests to accept both formats to maintain compatibility with both current stable versions (1.10, 1.11, 1.12) and nightly.

Changes:
- Modified two test assertions to accept either "0" or "00" format
- Tests now pass on Julia 1.10, 1.11, 1.12, and nightly

Fixes nightly CI failures where tests were failing due to formatting differences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)