### PR TITLE
Replace flags with out_flags in stream function

### DIFF
--- a/src/device/stream.jl
+++ b/src/device/stream.jl
@@ -332,7 +332,7 @@ function Base.write(
             s,
             buff_ptrs,
             samples_to_write - total_nwritten,
-            flags,
+            out_flags,
             0,
             timeout_us,
         )


### PR DESCRIPTION
The intention with the `out_flags` is to pick up status flags and communicate back to the caller, as in the `read` function. This fixes an unfortunate omission.
fixes: #113 